### PR TITLE
Fix archive img attributes and markup

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -99,11 +99,15 @@ function genesis_portfolio_custom_post_class( $classes ) {
 function genesis_portfolio_grid() {
 
 	$image = genesis_get_image( array(
-			'format'  => 'html',
-			'size'    => 'portfolio',
-			'context' => 'archive',
-			'attr'    => array ( 'alt' => the_title_attribute( 'echo=0' ), 'class' => 'portfolio-image' ),
-		) );
+		'format'  => 'html',
+		'size'    => 'portfolio',
+		'context' => 'archive',
+		'attr'    => array(
+			'alt'      => the_title_attribute( 'echo=0' ),
+			'class'    => 'portfolio-image',
+			'itemprop' => 'image',
+		),
+	) );
 
 	if ( $image ) {
 		printf( '<div class="portfolio-featured-image"><a href="%s" rel="bookmark">%s</a></div>', get_permalink(), $image );

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -110,7 +110,12 @@ function genesis_portfolio_grid() {
 	) );
 
 	if ( $image ) {
-		printf( '<div class="portfolio-featured-image"><a href="%s" rel="bookmark">%s</a></div>', get_permalink(), $image );
+		genesis_markup( array(
+			'open'    => '<div class="portfolio-featured-image"><a href="' . get_permalink() . '" aria-hidden="true">',
+			'close'   => '</a></div>',
+			'content' => $image,
+			'context' => 'portfolio-pro',
+		) );
 	}
 
 }


### PR DESCRIPTION
Small corrections to archive images as detailed in https://github.com/studiopress/genesis-portfolio-pro/issues/25.

- Use `genesis_markup` instead of `printf` to make markup filterable.
- Add aria-hidden to image link to prevent the link being read twice by screen readers (the item titles are also wrapped in links).
- Add `'itemprop' => 'image',` to images so they appear as part of structured data.
- Standards corrections to array formatting.