### PR TITLE
Fix alt attribute to use image alt meta instead of portfolio item title

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -100,13 +100,16 @@ function genesis_portfolio_custom_post_class( $classes ) {
  */
 function genesis_portfolio_grid() {
 
+	$image_id  = get_post_thumbnail_id();
+	$image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+
 	$image = genesis_get_image(
 		array(
 			'format'  => 'html',
 			'size'    => 'portfolio',
 			'context' => 'archive',
 			'attr'    => array(
-				'alt'      => the_title_attribute( 'echo=0' ),
+				'alt'      => $image_alt,
 				'class'    => 'portfolio-image',
 				'itemprop' => 'image',
 			),


### PR DESCRIPTION
This changes the alt attribute to use alt meta from the image, instead of the post title.

This prevents the title repeating, and allows custom alt text to be different than the portfolio item title.

<img width="1278" alt="edit_portfolio_item_ _dev_ _wordpress_and_portfolio_items" src="https://user-images.githubusercontent.com/647669/44986894-8283ff80-af85-11e8-956f-f4fe6f0992ae.png">

@marksabbath Please could you double check this when you get a moment? Thanks!