### PR TITLE
Add `grunt checktextdomain` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,12 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   grunt.initConfig({
-  pkg: grunt.file.readJSON('package.json'),
+    pkg: grunt.file.readJSON('package.json'),
     phpcs: {
       application: {
-          src: ['./*.php']
+        src: ['./*.php']
       },
       options: {
-          bin: 'vendor/bin/phpcs',
+        bin: 'vendor/bin/phpcs',
       }
     },
 
@@ -20,35 +20,35 @@ module.exports = function(grunt) {
           }]
         },
         files: [
-          { src: ['<%= pkg.main_plugin_file %>.php'], dest: './'}
-				]
+          { src: ['<%= pkg.main_plugin_file %>.php'], dest: './' }
+        ]
       }
     },
 
     // copying files to create the zip file
     copy: {
       // excluding not necessary files
-			main: {
-				src:  [
-				'**',
-				'!node_modules/**',
-				'!build/**',
-        '!vendor/**',
-				'!.git/**',
-        '!composer.json',
-        '!composer.lock',
-        '!package-lock.json',
-				'!Gruntfile.js',
-				'!package.json',
-				'!.gitignore',
-				'!.gitmodules',
-				'!**/Gruntfile.js',
-				'!**/package.json',
-        '!README.md',
-				'!**/*~'
-				],
-				dest: 'build/<%= pkg.name %>/'
-			},
+      main: {
+        src: [
+          '**',
+          '!node_modules/**',
+          '!build/**',
+          '!vendor/**',
+          '!.git/**',
+          '!composer.json',
+          '!composer.lock',
+          '!package-lock.json',
+          '!Gruntfile.js',
+          '!package.json',
+          '!.gitignore',
+          '!.gitmodules',
+          '!**/Gruntfile.js',
+          '!**/package.json',
+          '!README.md',
+          '!**/*~'
+        ],
+        dest: 'build/<%= pkg.name %>/'
+      },
     },
 
     // build zip file
@@ -69,34 +69,34 @@ module.exports = function(grunt) {
     },
 
     // Check correct text domain is last argument of i18n functions.
-		checktextdomain: {
-			options: {
-				text_domain: '<%= pkg.name %>',
-				keywords: [
-					'__:1,2d',
-					'_e:1,2d',
-					'_x:1,2c,3d',
-					'_ex:1,2c,3d',
-					'_n:1,2,4d',
-					'_nx:1,2,4c,5d',
-					'_n_noop:1,2,3d',
-					'_nx_noop:1,2,3c,4d',
-					'esc_attr__:1,2d',
-					'esc_html__:1,2d',
-					'esc_attr_e:1,2d',
-					'esc_html_e:1,2d',
-					'esc_attr_x:1,2c,3d',
-					'esc_html_x:1,2c,3d'
-				]
-			},
-			files: {
-				expand: true,
-				src: [
-					'*.php',
-					'lib/**/*.php'
-				]
-			}
-		},
+    checktextdomain: {
+      options: {
+        text_domain: '<%= pkg.name %>',
+        keywords: [
+          '__:1,2d',
+          '_e:1,2d',
+          '_x:1,2c,3d',
+          '_ex:1,2c,3d',
+          '_n:1,2,4d',
+          '_nx:1,2,4c,5d',
+          '_n_noop:1,2,3d',
+          '_nx_noop:1,2,3c,4d',
+          'esc_attr__:1,2d',
+          'esc_html__:1,2d',
+          'esc_attr_e:1,2d',
+          'esc_html_e:1,2d',
+          'esc_attr_x:1,2c,3d',
+          'esc_html_x:1,2c,3d'
+        ]
+      },
+      files: {
+        expand: true,
+        src: [
+          '*.php',
+          'lib/**/*.php'
+        ]
+      }
+    },
 
     // Check 'tested up to' headers against latest WordPress and WooCommerce.
     wptools: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,36 @@ module.exports = function(grunt) {
       }
     },
 
+    // Check correct text domain is last argument of i18n functions.
+		checktextdomain: {
+			options: {
+				text_domain: '<%= pkg.name %>',
+				keywords: [
+					'__:1,2d',
+					'_e:1,2d',
+					'_x:1,2c,3d',
+					'_ex:1,2c,3d',
+					'_n:1,2,4d',
+					'_nx:1,2,4c,5d',
+					'_n_noop:1,2,3d',
+					'_nx_noop:1,2,3c,4d',
+					'esc_attr__:1,2d',
+					'esc_html__:1,2d',
+					'esc_attr_e:1,2d',
+					'esc_html_e:1,2d',
+					'esc_attr_x:1,2c,3d',
+					'esc_html_x:1,2c,3d'
+				]
+			},
+			files: {
+				expand: true,
+				src: [
+					'*.php',
+					'lib/**/*.php'
+				]
+			}
+		},
+
     // Check 'tested up to' headers against latest WordPress and WooCommerce.
     wptools: {
       test_wordpress: {
@@ -84,8 +114,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-replace');
   grunt.loadNpmTasks('grunt-contrib-compress');
+  grunt.loadNpmTasks('grunt-checktextdomain');
   grunt.loadNpmTasks('grunt-wptools');
 
   grunt.registerTask('default', ['phpcs']);
-  grunt.registerTask('build', ['wptools', 'replace:pluginfile', 'copy:main', 'compress:main'])
+  grunt.registerTask('build', ['checktextdomain', 'wptools', 'replace:pluginfile', 'copy:main', 'compress:main'])
 };

--- a/lib/views/widget/portfolio.php
+++ b/lib/views/widget/portfolio.php
@@ -104,7 +104,7 @@ if ( $portfolio_query->have_posts() ) {
 
 			if ( ! empty( $instance['show_title'] ) ) {
 
-				$title = get_the_title() ? get_the_title() : __( '(no title)', 'genesis' );
+				$title = get_the_title() ? get_the_title() : __( '(no title)', 'genesis-portfolio-pro' );
 
 				$heading = genesis_a11y( 'headings' ) ? 'h4' : 'h2';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-nCaxyzfuDG4xByALw9Iwn6Jnjdplq7V7ppOLEzD7tJ7rEjmIoRQ2m+dbqhmQv32kG4mGBT0EENFiKajdLCB99Q==",
       "dev": true,
       "requires": {
-        "axios": "0.18.0"
+        "axios": "^0.18.0"
       }
     },
     "abbrev": {
@@ -26,10 +26,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -37,9 +37,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -47,7 +47,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -145,33 +145,33 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "requires": {
-        "ansi-bgblack": "0.1.1",
-        "ansi-bgblue": "0.1.1",
-        "ansi-bgcyan": "0.1.1",
-        "ansi-bggreen": "0.1.1",
-        "ansi-bgmagenta": "0.1.1",
-        "ansi-bgred": "0.1.1",
-        "ansi-bgwhite": "0.1.1",
-        "ansi-bgyellow": "0.1.1",
-        "ansi-black": "0.1.1",
-        "ansi-blue": "0.1.1",
-        "ansi-bold": "0.1.1",
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "ansi-grey": "0.1.1",
-        "ansi-hidden": "0.1.1",
-        "ansi-inverse": "0.1.1",
-        "ansi-italic": "0.1.1",
-        "ansi-magenta": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-reset": "0.1.1",
-        "ansi-strikethrough": "0.1.1",
-        "ansi-underline": "0.1.1",
-        "ansi-white": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "lazy-cache": "2.0.2"
+        "ansi-bgblack": "^0.1.1",
+        "ansi-bgblue": "^0.1.1",
+        "ansi-bgcyan": "^0.1.1",
+        "ansi-bggreen": "^0.1.1",
+        "ansi-bgmagenta": "^0.1.1",
+        "ansi-bgred": "^0.1.1",
+        "ansi-bgwhite": "^0.1.1",
+        "ansi-bgyellow": "^0.1.1",
+        "ansi-black": "^0.1.1",
+        "ansi-blue": "^0.1.1",
+        "ansi-bold": "^0.1.1",
+        "ansi-cyan": "^0.1.1",
+        "ansi-dim": "^0.1.1",
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "ansi-grey": "^0.1.1",
+        "ansi-hidden": "^0.1.1",
+        "ansi-inverse": "^0.1.1",
+        "ansi-italic": "^0.1.1",
+        "ansi-magenta": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-reset": "^0.1.1",
+        "ansi-strikethrough": "^0.1.1",
+        "ansi-underline": "^0.1.1",
+        "ansi-white": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "lazy-cache": "^2.0.1"
       }
     },
     "ansi-cyan": {
@@ -320,9 +320,9 @@
       "integrity": "sha1-qEaFeegfZzl7tWNMKZU77c0PVsA=",
       "dev": true,
       "requires": {
-        "cson-parser": "1.3.5",
-        "js-yaml": "3.12.0",
-        "lodash": "3.10.1"
+        "cson-parser": "^1.1.0",
+        "js-yaml": "^3.3.0",
+        "lodash": "^3.10.0"
       },
       "dependencies": {
         "lodash": {
@@ -345,15 +345,15 @@
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.1",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.3",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6",
-        "tar-stream": "1.6.1",
-        "walkdir": "0.0.11",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "walkdir": "^0.0.11",
+        "zip-stream": "^1.1.0"
       },
       "dependencies": {
         "async": {
@@ -362,7 +362,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         },
         "glob": {
@@ -371,12 +371,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -387,12 +387,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.10",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -401,12 +401,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -417,8 +417,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -426,7 +426,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -434,7 +434,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -447,7 +447,7 @@
       "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "requires": {
-        "make-iterator": "1.0.1"
+        "make-iterator": "^1.0.0"
       }
     },
     "arr-pluck": {
@@ -455,7 +455,7 @@
       "resolved": "https://registry.npmjs.org/arr-pluck/-/arr-pluck-0.1.0.tgz",
       "integrity": "sha1-+K1tcI+HkAiB4jr9gw1SKQp2Z3U=",
       "requires": {
-        "arr-map": "2.0.2"
+        "arr-map": "^2.0.0"
       }
     },
     "arr-union": {
@@ -474,9 +474,9 @@
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.4.tgz",
       "integrity": "sha512-BNcM+RXxndPxiZ2rd76k6nyQLRZr2/B/sdi8pQ+Joafr5AH279L40dfokSUTp8O+AaqYjXWhblBWa2st2nc4fQ==",
       "requires": {
-        "default-compare": "1.0.0",
-        "get-value": "2.0.6",
-        "kind-of": "5.1.0"
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
       }
     },
     "array-unique": {
@@ -489,7 +489,7 @@
       "resolved": "https://registry.npmjs.org/arrayify-compact/-/arrayify-compact-0.2.0.tgz",
       "integrity": "sha1-RZFw4VXKErtRRISDnJ1xUHyA7E0=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "asn1": {
@@ -499,7 +499,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assemble-core": {
@@ -507,13 +507,13 @@
       "resolved": "https://registry.npmjs.org/assemble-core/-/assemble-core-0.25.0.tgz",
       "integrity": "sha1-ZZF7/K+c1rFNm5HQMaDdmar0OWQ=",
       "requires": {
-        "assemble-fs": "0.6.0",
-        "assemble-render-file": "0.7.2",
-        "assemble-streams": "0.6.0",
-        "base-task": "0.6.2",
-        "define-property": "0.2.5",
-        "lazy-cache": "2.0.2",
-        "templates": "0.24.3"
+        "assemble-fs": "^0.6.0",
+        "assemble-render-file": "^0.7.1",
+        "assemble-streams": "^0.6.0",
+        "base-task": "^0.6.1",
+        "define-property": "^0.2.5",
+        "lazy-cache": "^2.0.1",
+        "templates": "^0.24.0"
       }
     },
     "assemble-fs": {
@@ -521,13 +521,13 @@
       "resolved": "https://registry.npmjs.org/assemble-fs/-/assemble-fs-0.6.0.tgz",
       "integrity": "sha1-uky+t0tdG97m1SipZa07fZbe8Og=",
       "requires": {
-        "assemble-handle": "0.1.4",
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "stream-combiner": "0.2.2",
-        "through2": "2.0.3",
-        "vinyl-fs": "2.4.4"
+        "assemble-handle": "^0.1.2",
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "stream-combiner": "^0.2.2",
+        "through2": "^2.0.1",
+        "vinyl-fs": "^2.4.3"
       }
     },
     "assemble-handle": {
@@ -535,7 +535,7 @@
       "resolved": "https://registry.npmjs.org/assemble-handle/-/assemble-handle-0.1.4.tgz",
       "integrity": "sha1-6De1uyPnXJsFJX2AfhYvaSzOIW4=",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.3"
       }
     },
     "assemble-loader": {
@@ -543,16 +543,16 @@
       "resolved": "https://registry.npmjs.org/assemble-loader/-/assemble-loader-0.6.1.tgz",
       "integrity": "sha1-0GmqZBhOFzKEP+HsGAghI1dpVdg=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.2.4",
-        "fs-exists-sync": "0.1.0",
-        "has-glob": "0.1.1",
-        "is-registered": "0.1.5",
-        "is-valid-glob": "0.3.0",
-        "is-valid-instance": "0.1.0",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "load-templates": "0.11.4"
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.2.4",
+        "fs-exists-sync": "^0.1.0",
+        "has-glob": "^0.1.1",
+        "is-registered": "^0.1.5",
+        "is-valid-glob": "^0.3.0",
+        "is-valid-instance": "^0.1.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "load-templates": "^0.11.3"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -560,8 +560,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -571,11 +571,11 @@
       "resolved": "https://registry.npmjs.org/assemble-render-file/-/assemble-render-file-0.7.2.tgz",
       "integrity": "sha1-g6qV9e131ctK6oq8dPIkoVRVccY=",
       "requires": {
-        "debug": "2.6.9",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "through2": "2.0.3"
+        "debug": "^2.2.0",
+        "is-valid-app": "^0.1.2",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "is-valid-app": {
@@ -583,10 +583,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -594,8 +594,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -605,13 +605,13 @@
       "resolved": "https://registry.npmjs.org/assemble-streams/-/assemble-streams-0.6.0.tgz",
       "integrity": "sha1-kOkhaoNpltJoNwvtrHG7MdjJq18=",
       "requires": {
-        "assemble-handle": "0.1.4",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "match-file": "0.2.2",
-        "src-stream": "0.1.1",
-        "through2": "2.0.3"
+        "assemble-handle": "^0.1.2",
+        "is-registered": "^0.1.4",
+        "is-valid-instance": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "match-file": "^0.2.0",
+        "src-stream": "^0.1.1",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -619,8 +619,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -636,9 +636,9 @@
       "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.7.tgz",
       "integrity": "sha512-tYlXoIH6RM2rclkx9uLXDKPKrDGsnxoWHE2J5+9tq2StAXeAAo8hLPZtOqwt22p8r6H5hnMgd8Oz8qPJl3W31g==",
       "requires": {
-        "assign-symbols": "0.1.1",
-        "is-primitive": "2.0.0",
-        "kind-of": "5.1.0"
+        "assign-symbols": "^0.1.1",
+        "is-primitive": "^2.0.0",
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "assign-symbols": {
@@ -668,10 +668,10 @@
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
       "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0",
-        "process-nextick-args": "1.0.7",
-        "stream-exhaust": "1.0.2"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^1.0.7",
+        "stream-exhaust": "^1.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -696,8 +696,8 @@
       "resolved": "https://registry.npmjs.org/async-helpers/-/async-helpers-0.3.17.tgz",
       "integrity": "sha512-LfgCyvmK6ZiC7pyqOgli2zfkWL4HYbEb+HXvGgdmqVBgsOOtQz5rSF8Ii/H/1cNNtrfj1KsdZE/lUMeIY3Qcwg==",
       "requires": {
-        "co": "4.6.0",
-        "kind-of": "6.0.2"
+        "co": "^4.6.0",
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -712,7 +712,7 @@
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-0.2.1.tgz",
       "integrity": "sha1-dnRi1XOACNx16sQkYiNSjyE3E5Y=",
       "requires": {
-        "async-done": "0.4.0"
+        "async-done": "^0.4.0"
       },
       "dependencies": {
         "async-done": {
@@ -720,10 +720,10 @@
           "resolved": "https://registry.npmjs.org/async-done/-/async-done-0.4.0.tgz",
           "integrity": "sha1-q4BT9fYikPi/xY83zZtzBwszB7k=",
           "requires": {
-            "end-of-stream": "0.1.5",
-            "next-tick": "0.2.2",
-            "once": "1.4.0",
-            "stream-exhaust": "1.0.2"
+            "end-of-stream": "^0.1.4",
+            "next-tick": "^0.2.2",
+            "once": "^1.3.0",
+            "stream-exhaust": "^1.0.0"
           }
         },
         "end-of-stream": {
@@ -731,7 +731,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
           "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
           "requires": {
-            "once": "1.3.3"
+            "once": "~1.3.0"
           },
           "dependencies": {
             "once": {
@@ -739,7 +739,7 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             }
           }
@@ -773,8 +773,8 @@
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
-        "follow-redirects": "1.5.8",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "bach": {
@@ -782,14 +782,14 @@
       "resolved": "https://registry.npmjs.org/bach/-/bach-0.5.0.tgz",
       "integrity": "sha1-P/pqN0F3PrwNJL5f2kvF6FtbHaE=",
       "requires": {
-        "async-done": "1.3.1",
-        "async-settle": "0.2.1",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.initial": "4.1.1",
-        "lodash.last": "3.0.0",
-        "lodash.map": "4.6.0",
+        "async-done": "^1.1.1",
+        "async-settle": "^0.2.1",
+        "lodash.filter": "^4.1.0",
+        "lodash.flatten": "^4.0.0",
+        "lodash.foreach": "^4.0.0",
+        "lodash.initial": "^4.0.1",
+        "lodash.last": "^3.0.0",
+        "lodash.map": "^4.1.0",
         "now-and-later": "0.0.6"
       }
     },
@@ -803,13 +803,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -817,7 +817,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -825,7 +825,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -833,7 +833,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -841,9 +841,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -863,13 +863,13 @@
       "resolved": "https://registry.npmjs.org/base-argv/-/base-argv-0.4.5.tgz",
       "integrity": "sha1-BalXHNwnaUDeGW/8h07uuJnLED0=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "arr-union": "3.1.0",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "expand-args": "0.4.3",
-        "extend-shallow": "2.0.1",
-        "lazy-cache": "1.0.4"
+        "arr-diff": "^2.0.0",
+        "arr-union": "^3.1.0",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "expand-args": "^0.4.1",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -884,8 +884,8 @@
       "resolved": "https://registry.npmjs.org/base-cli/-/base-cli-0.5.0.tgz",
       "integrity": "sha1-U+Zdjg9bKKoRBo/sjdTpXXLvPOg=",
       "requires": {
-        "base-argv": "0.4.5",
-        "base-config": "0.5.2"
+        "base-argv": "^0.4.2",
+        "base-config": "^0.5.2"
       }
     },
     "base-cli-process": {
@@ -893,26 +893,26 @@
       "resolved": "https://registry.npmjs.org/base-cli-process/-/base-cli-process-0.1.19.tgz",
       "integrity": "sha1-Mg08gVTfcQltSBgY52/m1+R5NjY=",
       "requires": {
-        "arr-union": "3.1.0",
-        "arrayify-compact": "0.2.0",
-        "base-cli": "0.5.0",
-        "base-cli-schema": "0.1.19",
-        "base-config-process": "0.1.9",
-        "base-cwd": "0.3.4",
-        "base-option": "0.8.4",
-        "base-pkg": "0.2.5",
-        "debug": "2.6.9",
-        "export-files": "2.1.1",
-        "fs-exists-sync": "0.1.0",
-        "is-valid-app": "0.2.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "merge-deep": "3.0.2",
-        "mixin-deep": "1.3.1",
-        "object.pick": "1.3.0",
-        "pad-right": "0.2.2",
-        "union-value": "1.0.0"
+        "arr-union": "^3.1.0",
+        "arrayify-compact": "^0.2.0",
+        "base-cli": "^0.5.0",
+        "base-cli-schema": "^0.1.19",
+        "base-config-process": "^0.1.9",
+        "base-cwd": "^0.3.4",
+        "base-option": "^0.8.4",
+        "base-pkg": "^0.2.4",
+        "debug": "^2.6.2",
+        "export-files": "^2.1.1",
+        "fs-exists-sync": "^0.1.0",
+        "is-valid-app": "^0.2.1",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "log-utils": "^0.2.1",
+        "merge-deep": "^3.0.0",
+        "mixin-deep": "^1.2.0",
+        "object.pick": "^1.2.0",
+        "pad-right": "^0.2.2",
+        "union-value": "^1.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -920,7 +920,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -930,23 +930,23 @@
       "resolved": "https://registry.npmjs.org/base-cli-schema/-/base-cli-schema-0.1.19.tgz",
       "integrity": "sha1-gfQYL0zwu4NnHxF2PknLBbkugkE=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.2.1",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "falsey": "0.3.2",
-        "fs-exists-sync": "0.1.0",
-        "has-glob": "0.1.1",
-        "has-value": "0.3.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "map-schema": "0.2.4",
-        "merge-deep": "3.0.2",
-        "mixin-deep": "1.3.1",
-        "resolve": "1.8.1",
-        "tableize-object": "0.1.0"
+        "arr-flatten": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "falsey": "^0.3.0",
+        "fs-exists-sync": "^0.1.0",
+        "has-glob": "^0.1.1",
+        "has-value": "^0.3.1",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "map-schema": "^0.2.3",
+        "merge-deep": "^3.0.0",
+        "mixin-deep": "^1.1.3",
+        "resolve": "^1.1.7",
+        "tableize-object": "^0.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -954,7 +954,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -964,9 +964,9 @@
       "resolved": "https://registry.npmjs.org/base-compose/-/base-compose-0.2.1.tgz",
       "integrity": "sha1-reSal/WiRIvVa8s0C090aMb74tc=",
       "requires": {
-        "copy-task": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1"
+        "copy-task": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3"
       }
     },
     "base-config": {
@@ -974,10 +974,10 @@
       "resolved": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz",
       "integrity": "sha1-q2A8AdExWL4uYux3/7Ix4o9Ijh8=",
       "requires": {
-        "isobject": "2.1.0",
-        "lazy-cache": "1.0.4",
-        "map-config": "0.5.0",
-        "resolve-dir": "0.1.1"
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "map-config": "^0.5.0",
+        "resolve-dir": "^0.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -992,16 +992,16 @@
       "resolved": "https://registry.npmjs.org/base-config-process/-/base-config-process-0.1.9.tgz",
       "integrity": "sha1-imOmGYnuY1UMyM/cP2wCdf2gtG4=",
       "requires": {
-        "base-config": "0.5.2",
-        "base-config-schema": "0.1.24",
-        "base-cwd": "0.3.4",
-        "base-option": "0.8.4",
-        "debug": "2.6.9",
-        "export-files": "2.1.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "micromatch": "2.3.11",
-        "mixin-deep": "1.3.1"
+        "base-config": "^0.5.2",
+        "base-config-schema": "^0.1.18",
+        "base-cwd": "^0.3.4",
+        "base-option": "^0.8.4",
+        "debug": "^2.2.0",
+        "export-files": "^2.1.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "micromatch": "^2.3.10",
+        "mixin-deep": "^1.1.3"
       }
     },
     "base-config-schema": {
@@ -1009,24 +1009,24 @@
       "resolved": "https://registry.npmjs.org/base-config-schema/-/base-config-schema-0.1.24.tgz",
       "integrity": "sha1-T74UvsVtwa7ef+3QaSjpGfhyH6k=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "base-pkg": "0.2.5",
-        "camel-case": "3.0.0",
-        "debug": "2.6.9",
-        "define-property": "1.0.0",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "has-glob": "1.0.0",
-        "has-value": "0.3.1",
-        "inflection": "1.12.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "load-templates": "1.0.2",
-        "map-schema": "0.2.4",
-        "matched": "0.4.4",
-        "mixin-deep": "1.3.1",
-        "resolve": "1.8.1"
+        "arr-flatten": "^1.0.3",
+        "array-unique": "^0.3.2",
+        "base-pkg": "^0.2.4",
+        "camel-case": "^3.0.0",
+        "debug": "^2.6.6",
+        "define-property": "^1.0.0",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "has-glob": "^1.0.0",
+        "has-value": "^0.3.1",
+        "inflection": "^1.12.0",
+        "kind-of": "^3.2.0",
+        "lazy-cache": "^2.0.2",
+        "load-templates": "^1.0.2",
+        "map-schema": "^0.2.4",
+        "matched": "^0.4.4",
+        "mixin-deep": "^1.2.0",
+        "resolve": "^1.3.3"
       },
       "dependencies": {
         "array-unique": {
@@ -1049,7 +1049,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "file-contents": {
@@ -1057,14 +1057,14 @@
           "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-1.0.1.tgz",
           "integrity": "sha1-ryW7/T00RjhPrYBmSdiAi8/uHsg=",
           "requires": {
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "is-buffer": "1.1.6",
-            "kind-of": "3.2.2",
-            "lazy-cache": "2.0.2",
-            "strip-bom-buffer": "0.1.1",
-            "strip-bom-string": "0.1.2",
-            "through2": "2.0.3"
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "is-buffer": "^1.1.4",
+            "kind-of": "^3.1.0",
+            "lazy-cache": "^2.0.2",
+            "strip-bom-buffer": "^0.1.1",
+            "strip-bom-string": "^0.1.2",
+            "through2": "^2.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -1072,7 +1072,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -1080,7 +1080,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-data-descriptor": {
@@ -1088,7 +1088,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-descriptor": {
@@ -1096,9 +1096,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               },
               "dependencies": {
                 "kind-of": {
@@ -1115,12 +1115,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-glob": {
@@ -1128,7 +1128,7 @@
           "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1136,7 +1136,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -1151,7 +1151,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -1166,9 +1166,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1188,7 +1188,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "load-templates": {
@@ -1196,14 +1196,14 @@
           "resolved": "https://registry.npmjs.org/load-templates/-/load-templates-1.0.2.tgz",
           "integrity": "sha1-CfOOlcjvS/t4W9f8qOv9MrIwvIc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "file-contents": "1.0.1",
-            "glob-parent": "3.1.0",
-            "is-glob": "3.1.0",
-            "kind-of": "3.2.2",
-            "lazy-cache": "2.0.2",
-            "matched": "0.4.4",
-            "vinyl": "2.2.0"
+            "extend-shallow": "^2.0.1",
+            "file-contents": "^1.0.0",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^3.1.0",
+            "kind-of": "^3.1.0",
+            "lazy-cache": "^2.0.2",
+            "matched": "^0.4.4",
+            "vinyl": "^2.0.1"
           }
         },
         "matched": {
@@ -1211,15 +1211,15 @@
           "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.3",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           },
           "dependencies": {
             "has-glob": {
@@ -1227,7 +1227,7 @@
               "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
               "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
               "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.1"
               }
             },
             "is-glob": {
@@ -1235,7 +1235,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -1250,12 +1250,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "requires": {
-            "clone": "2.1.2",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.2",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -1265,9 +1265,9 @@
       "resolved": "https://registry.npmjs.org/base-cwd/-/base-cwd-0.3.4.tgz",
       "integrity": "sha1-TQCrY1CgRuGtSrnCMm2heUs+TwE=",
       "requires": {
-        "empty-dir": "0.2.1",
-        "find-pkg": "0.1.2",
-        "is-valid-app": "0.2.1"
+        "empty-dir": "^0.2.0",
+        "find-pkg": "^0.1.2",
+        "is-valid-app": "^0.2.0"
       }
     },
     "base-data": {
@@ -1275,22 +1275,22 @@
       "resolved": "https://registry.npmjs.org/base-data/-/base-data-0.6.2.tgz",
       "integrity": "sha512-wH2ViG6CUO2AaeHSEt6fJTyQAk5gl0oY456DoSC5h8mnHrWUbvdctMCuF53CXgBmi0oalZQppKNH0iamG5+uqw==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "cache-base": "1.0.1",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "has-glob": "1.0.0",
-        "has-value": "1.0.0",
-        "is-registered": "0.1.5",
-        "is-valid-app": "0.3.0",
-        "kind-of": "5.1.0",
-        "lazy-cache": "2.0.2",
-        "merge-value": "1.0.0",
-        "mixin-deep": "1.3.1",
-        "read-file": "0.2.0",
-        "resolve-glob": "1.0.0",
-        "set-value": "2.0.0",
-        "union-value": "1.0.0"
+        "arr-flatten": "^1.1.0",
+        "cache-base": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "has-glob": "^1.0.0",
+        "has-value": "^1.0.0",
+        "is-registered": "^0.1.5",
+        "is-valid-app": "^0.3.0",
+        "kind-of": "^5.0.0",
+        "lazy-cache": "^2.0.2",
+        "merge-value": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "read-file": "^0.2.0",
+        "resolve-glob": "^1.0.0",
+        "set-value": "^2.0.0",
+        "union-value": "^1.0.0"
       },
       "dependencies": {
         "has-glob": {
@@ -1298,7 +1298,7 @@
           "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "has-value": {
@@ -1306,9 +1306,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "is-valid-app": {
@@ -1316,10 +1316,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
           "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.3.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.6.3",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.3.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "is-valid-instance": {
@@ -1327,8 +1327,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
           "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
           "requires": {
-            "isobject": "3.0.1",
-            "pascalcase": "0.1.1"
+            "isobject": "^3.0.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "isobject": {
@@ -1341,10 +1341,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -1354,11 +1354,11 @@
       "resolved": "https://registry.npmjs.org/base-engines/-/base-engines-0.2.1.tgz",
       "integrity": "sha1-aXgAyoq4iKM3iXONv6zLgYoqWns=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "engine-cache": "0.19.4",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2"
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "engine-cache": "^0.19.0",
+        "is-valid-app": "^0.1.2",
+        "lazy-cache": "^2.0.1"
       },
       "dependencies": {
         "is-valid-app": {
@@ -1366,10 +1366,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -1377,8 +1377,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -1388,18 +1388,18 @@
       "resolved": "https://registry.npmjs.org/base-env/-/base-env-0.3.1.tgz",
       "integrity": "sha512-/HxC8QV1m/bWqvjcu4WZl4Um1HRpTAjuY31uiFUEukXsXge4WIvNvGKG/gCs2PrpBFPCybowA406V/ivdPknpQ==",
       "requires": {
-        "base-namespace": "0.2.0",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "is-absolute": "0.2.6",
-        "is-valid-app": "0.1.2",
-        "is-valid-instance": "0.1.0",
-        "kind-of": "3.2.2",
-        "os-homedir": "1.0.2",
-        "resolve-file": "0.3.0"
+        "base-namespace": "^0.2.0",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.2",
+        "is-absolute": "^0.2.5",
+        "is-valid-app": "^0.1.0",
+        "is-valid-instance": "^0.1.0",
+        "kind-of": "^3.0.3",
+        "os-homedir": "^1.0.1",
+        "resolve-file": "^0.3.0"
       },
       "dependencies": {
         "cwd": {
@@ -1407,8 +1407,8 @@
           "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
           "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
           "requires": {
-            "find-pkg": "0.1.2",
-            "fs-exists-sync": "0.1.0"
+            "find-pkg": "^0.1.2",
+            "fs-exists-sync": "^0.1.0"
           }
         },
         "is-valid-app": {
@@ -1416,10 +1416,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -1427,8 +1427,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "kind-of": {
@@ -1436,7 +1436,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "resolve-file": {
@@ -1444,13 +1444,13 @@
           "resolved": "https://registry.npmjs.org/resolve-file/-/resolve-file-0.3.0.tgz",
           "integrity": "sha1-EeH7RkVm06fFAMt+lIHo8LAKFO8=",
           "requires": {
-            "cwd": "0.10.0",
-            "expand-tilde": "2.0.2",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "homedir-polyfill": "1.0.1",
-            "lazy-cache": "2.0.2",
-            "resolve": "1.8.1"
+            "cwd": "^0.10.0",
+            "expand-tilde": "^2.0.2",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "homedir-polyfill": "^1.0.1",
+            "lazy-cache": "^2.0.2",
+            "resolve": "^1.2.0"
           }
         }
       }
@@ -1460,24 +1460,24 @@
       "resolved": "https://registry.npmjs.org/base-generators/-/base-generators-0.4.6.tgz",
       "integrity": "sha1-4amTYh5bRCr44MgRMVoyb5h8nqY=",
       "requires": {
-        "async-each-series": "1.1.0",
-        "base-compose": "0.2.1",
-        "base-cwd": "0.3.4",
-        "base-data": "0.6.2",
-        "base-env": "0.3.1",
-        "base-option": "0.8.4",
-        "base-pkg": "0.2.5",
-        "base-plugins": "0.4.13",
-        "base-task": "0.6.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "global-modules": "0.2.3",
-        "is-valid-app": "0.2.1",
-        "is-valid-instance": "0.2.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1"
+        "async-each-series": "^1.1.0",
+        "base-compose": "^0.2.1",
+        "base-cwd": "^0.3.1",
+        "base-data": "^0.6.0",
+        "base-env": "^0.3.0",
+        "base-option": "^0.8.4",
+        "base-pkg": "^0.2.4",
+        "base-plugins": "^0.4.13",
+        "base-task": "^0.6.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "global-modules": "^0.2.2",
+        "is-valid-app": "^0.2.0",
+        "is-valid-instance": "^0.2.0",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "kind-of": {
@@ -1485,7 +1485,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1495,11 +1495,11 @@
       "resolved": "https://registry.npmjs.org/base-helpers/-/base-helpers-0.1.1.tgz",
       "integrity": "sha1-2k4eKy+ACOzc6T8R79223gYzP7M=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2",
-        "load-helpers": "0.2.11"
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "is-valid-app": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "load-helpers": "^0.2.11"
       },
       "dependencies": {
         "is-valid-app": {
@@ -1507,10 +1507,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -1518,8 +1518,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -1529,7 +1529,7 @@
       "resolved": "https://registry.npmjs.org/base-namespace/-/base-namespace-0.2.0.tgz",
       "integrity": "sha1-RLLLumZ1Y8xE5trrTv5AO7CrPaA=",
       "requires": {
-        "is-valid-app": "0.1.2"
+        "is-valid-app": "^0.1.0"
       },
       "dependencies": {
         "is-valid-app": {
@@ -1537,10 +1537,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -1548,8 +1548,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -1559,14 +1559,14 @@
       "resolved": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
       "integrity": "sha1-EUF/qSRPInpNU3tNKRcjRieH1cc=",
       "requires": {
-        "define-property": "0.2.5",
-        "get-value": "2.0.6",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "option-cache": "3.5.0",
-        "set-value": "0.3.3"
+        "define-property": "^0.2.5",
+        "get-value": "^2.0.6",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "option-cache": "^3.4.0",
+        "set-value": "^0.3.3"
       }
     },
     "base-pkg": {
@@ -1574,14 +1574,14 @@
       "resolved": "https://registry.npmjs.org/base-pkg/-/base-pkg-0.2.5.tgz",
       "integrity": "sha512-/POxajlgBhVsknwLXnqnbp//bAMh7SkDgHF+z/uoYnFqk46e05c3MxSEmn5vFCB8g4rHHKxAPLKrU/4Yb3vUdA==",
       "requires": {
-        "cache-base": "1.0.1",
-        "debug": "2.6.9",
-        "define-property": "1.0.0",
-        "expand-pkg": "0.1.9",
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.3.0",
-        "log-utils": "0.2.1",
-        "pkg-store": "0.2.2"
+        "cache-base": "^1.0.0",
+        "debug": "^2.6.8",
+        "define-property": "^1.0.0",
+        "expand-pkg": "^0.1.8",
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.3.0",
+        "log-utils": "^0.2.1",
+        "pkg-store": "^0.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -1589,7 +1589,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1597,7 +1597,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1605,7 +1605,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1613,9 +1613,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-valid-app": {
@@ -1623,10 +1623,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
           "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.3.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.6.3",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.3.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "is-valid-instance": {
@@ -1634,8 +1634,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
           "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
           "requires": {
-            "isobject": "3.0.1",
-            "pascalcase": "0.1.1"
+            "isobject": "^3.0.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "isobject": {
@@ -1655,9 +1655,9 @@
       "resolved": "https://registry.npmjs.org/base-plugins/-/base-plugins-0.4.13.tgz",
       "integrity": "sha1-kd8XjcN/hoQt6ihteeSPuGtarD0=",
       "requires": {
-        "define-property": "0.2.5",
-        "is-registered": "0.1.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "is-registered": "^0.1.5",
+        "isobject": "^2.1.0"
       }
     },
     "base-questions": {
@@ -1665,15 +1665,15 @@
       "resolved": "https://registry.npmjs.org/base-questions/-/base-questions-0.7.4.tgz",
       "integrity": "sha1-9k+EgmHtbIKPSYPXgS9A0wN4IUY=",
       "requires": {
-        "base-store": "0.4.4",
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "question-store": "0.11.1"
+        "base-store": "^0.4.4",
+        "clone-deep": "^0.2.4",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "question-store": "^0.11.0"
       }
     },
     "base-routes": {
@@ -1681,11 +1681,11 @@
       "resolved": "https://registry.npmjs.org/base-routes/-/base-routes-0.2.2.tgz",
       "integrity": "sha1-CmFNFy1JBF2Mk4dxP4YN88QFNB4=",
       "requires": {
-        "debug": "2.6.9",
-        "en-route": "0.7.5",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "template-error": "0.1.2"
+        "debug": "^2.2.0",
+        "en-route": "^0.7.5",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "template-error": "^0.1.2"
       }
     },
     "base-runtimes": {
@@ -1693,12 +1693,12 @@
       "resolved": "https://registry.npmjs.org/base-runtimes/-/base-runtimes-0.2.0.tgz",
       "integrity": "sha1-GI4+ZoJMyxWYsyh7TqW5NaG4UEU=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.1.5",
-        "micromatch": "2.3.11",
-        "time-diff": "0.3.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.1.4",
+        "micromatch": "^2.3.10",
+        "time-diff": "^0.3.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -1706,33 +1706,33 @@
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
           "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
           "requires": {
-            "ansi-bgblack": "0.1.1",
-            "ansi-bgblue": "0.1.1",
-            "ansi-bgcyan": "0.1.1",
-            "ansi-bggreen": "0.1.1",
-            "ansi-bgmagenta": "0.1.1",
-            "ansi-bgred": "0.1.1",
-            "ansi-bgwhite": "0.1.1",
-            "ansi-bgyellow": "0.1.1",
-            "ansi-black": "0.1.1",
-            "ansi-blue": "0.1.1",
-            "ansi-bold": "0.1.1",
-            "ansi-cyan": "0.1.1",
-            "ansi-dim": "0.1.1",
-            "ansi-gray": "0.1.1",
-            "ansi-green": "0.1.1",
-            "ansi-grey": "0.1.1",
-            "ansi-hidden": "0.1.1",
-            "ansi-inverse": "0.1.1",
-            "ansi-italic": "0.1.1",
-            "ansi-magenta": "0.1.1",
-            "ansi-red": "0.1.1",
-            "ansi-reset": "0.1.1",
-            "ansi-strikethrough": "0.1.1",
-            "ansi-underline": "0.1.1",
-            "ansi-white": "0.1.1",
-            "ansi-yellow": "0.1.1",
-            "lazy-cache": "0.2.7"
+            "ansi-bgblack": "^0.1.1",
+            "ansi-bgblue": "^0.1.1",
+            "ansi-bgcyan": "^0.1.1",
+            "ansi-bggreen": "^0.1.1",
+            "ansi-bgmagenta": "^0.1.1",
+            "ansi-bgred": "^0.1.1",
+            "ansi-bgwhite": "^0.1.1",
+            "ansi-bgyellow": "^0.1.1",
+            "ansi-black": "^0.1.1",
+            "ansi-blue": "^0.1.1",
+            "ansi-bold": "^0.1.1",
+            "ansi-cyan": "^0.1.1",
+            "ansi-dim": "^0.1.1",
+            "ansi-gray": "^0.1.1",
+            "ansi-green": "^0.1.1",
+            "ansi-grey": "^0.1.1",
+            "ansi-hidden": "^0.1.1",
+            "ansi-inverse": "^0.1.1",
+            "ansi-italic": "^0.1.1",
+            "ansi-magenta": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "ansi-reset": "^0.1.1",
+            "ansi-strikethrough": "^0.1.1",
+            "ansi-underline": "^0.1.1",
+            "ansi-white": "^0.1.1",
+            "ansi-yellow": "^0.1.1",
+            "lazy-cache": "^0.2.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -1747,13 +1747,13 @@
           "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
           "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
           "requires": {
-            "ansi-colors": "0.1.0",
-            "error-symbol": "0.1.0",
-            "info-symbol": "0.1.0",
-            "log-ok": "0.1.1",
-            "success-symbol": "0.1.0",
-            "time-stamp": "1.1.0",
-            "warning-symbol": "0.1.0"
+            "ansi-colors": "^0.1.0",
+            "error-symbol": "^0.1.0",
+            "info-symbol": "^0.1.0",
+            "log-ok": "^0.1.1",
+            "success-symbol": "^0.1.0",
+            "time-stamp": "^1.0.1",
+            "warning-symbol": "^0.1.0"
           }
         }
       }
@@ -1763,13 +1763,13 @@
       "resolved": "https://registry.npmjs.org/base-store/-/base-store-0.4.4.tgz",
       "integrity": "sha1-JY32uKYu4G/xUADJSdD9fCi68mY=",
       "requires": {
-        "data-store": "0.16.1",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "project-name": "0.2.6"
+        "data-store": "^0.16.0",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "is-registered": "^0.1.4",
+        "is-valid-instance": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "project-name": "^0.2.5"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -1777,8 +1777,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -1788,8 +1788,8 @@
       "resolved": "https://registry.npmjs.org/base-task/-/base-task-0.6.2.tgz",
       "integrity": "sha1-Rn1guuBzezuJab/1f6RElJiZgcA=",
       "requires": {
-        "composer": "0.13.0",
-        "is-valid-app": "0.1.2"
+        "composer": "^0.13.0",
+        "is-valid-app": "^0.1.0"
       },
       "dependencies": {
         "is-valid-app": {
@@ -1797,10 +1797,10 @@
           "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -1808,8 +1808,8 @@
           "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -1827,7 +1827,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -1836,8 +1836,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "block-stream": {
@@ -1847,7 +1847,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "brace-expansion": {
@@ -1855,7 +1855,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1864,9 +1864,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.3"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "buffer": {
@@ -1875,8 +1875,8 @@
       "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -1885,8 +1885,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -1918,15 +1918,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -1934,9 +1934,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "isobject": {
@@ -1949,10 +1949,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -1962,8 +1962,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -1977,8 +1977,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2001,11 +2001,11 @@
       "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chownr": {
@@ -2020,10 +2020,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -2038,7 +2038,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -2061,11 +2061,11 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "shallow-clone": "0.1.2"
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
       },
       "dependencies": {
         "kind-of": {
@@ -2073,7 +2073,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -2093,9 +2093,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       }
     },
     "co": {
@@ -2119,8 +2119,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -2150,7 +2150,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "common-config": {
@@ -2158,19 +2158,19 @@
       "resolved": "https://registry.npmjs.org/common-config/-/common-config-0.1.0.tgz",
       "integrity": "sha1-0fGnQa+gy/al7wl1K9/C5nfYtO8=",
       "requires": {
-        "composer": "0.13.0",
-        "data-store": "0.16.1",
-        "get-value": "2.0.6",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "object.pick": "1.3.0",
-        "omit-empty": "0.4.1",
-        "question-cache": "0.4.0",
-        "set-value": "0.3.3",
-        "strip-color": "0.1.0",
-        "tableize-object": "0.1.0",
-        "text-table": "0.2.0",
-        "yargs-parser": "2.4.1"
+        "composer": "^0.13.0",
+        "data-store": "^0.16.1",
+        "get-value": "^2.0.6",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.2.0",
+        "object.pick": "^1.1.2",
+        "omit-empty": "^0.4.1",
+        "question-cache": "^0.4.0",
+        "set-value": "^0.3.3",
+        "strip-color": "^0.1.0",
+        "tableize-object": "^0.1.0",
+        "text-table": "^0.2.0",
+        "yargs-parser": "^2.4.0"
       },
       "dependencies": {
         "has-values": {
@@ -2183,25 +2183,25 @@
           "resolved": "https://registry.npmjs.org/question-cache/-/question-cache-0.4.0.tgz",
           "integrity": "sha1-4rmTf8X7fcYPu58QXx+iVLM96n0=",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "arr-union": "3.1.0",
+            "arr-flatten": "^1.0.1",
+            "arr-union": "^3.1.0",
             "async": "1.5.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "inquirer2": "0.1.1",
-            "is-answer": "0.1.1",
-            "isobject": "2.1.0",
-            "lazy-cache": "1.0.4",
-            "mixin-deep": "1.3.1",
-            "omit-empty": "0.3.6",
-            "option-cache": "3.5.0",
-            "os-homedir": "1.0.2",
-            "project-name": "0.2.6",
-            "set-value": "0.3.3",
-            "to-choices": "0.2.0",
-            "use": "1.1.2"
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "inquirer2": "^0.1.1",
+            "is-answer": "^0.1.0",
+            "isobject": "^2.0.0",
+            "lazy-cache": "^1.0.3",
+            "mixin-deep": "^1.1.3",
+            "omit-empty": "^0.3.6",
+            "option-cache": "^3.3.5",
+            "os-homedir": "^1.0.1",
+            "project-name": "^0.2.4",
+            "set-value": "^0.3.3",
+            "to-choices": "^0.2.0",
+            "use": "^1.1.2"
           },
           "dependencies": {
             "lazy-cache": {
@@ -2214,10 +2214,10 @@
               "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.3.6.tgz",
               "integrity": "sha1-bThAXyqmHJEetQT+aIBcVm2FwxY=",
               "requires": {
-                "has-values": "0.1.4",
-                "is-date-object": "1.0.1",
-                "isobject": "2.1.0",
-                "reduce-object": "0.1.3"
+                "has-values": "^0.1.4",
+                "is-date-object": "^1.0.1",
+                "isobject": "^2.0.0",
+                "reduce-object": "^0.1.3"
               }
             }
           }
@@ -2234,18 +2234,18 @@
       "resolved": "https://registry.npmjs.org/composer/-/composer-0.13.0.tgz",
       "integrity": "sha1-HbyxXxmpBt7uSanD0TfmVLvG0OI=",
       "requires": {
-        "array-unique": "0.2.1",
-        "bach": "0.5.0",
-        "co": "4.6.0",
-        "component-emitter": "1.2.1",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "is-generator": "1.0.3",
-        "is-glob": "2.0.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "micromatch": "2.3.11",
-        "nanoseconds": "0.1.0"
+        "array-unique": "^0.2.1",
+        "bach": "^0.5.0",
+        "co": "^4.6.0",
+        "component-emitter": "^1.2.1",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "is-generator": "^1.0.3",
+        "is-glob": "^2.0.1",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "micromatch": "^2.3.8",
+        "nanoseconds": "^0.1.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -2258,7 +2258,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -2269,10 +2269,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "concat-map": {
@@ -2296,7 +2296,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "copy-descriptor": {
@@ -2320,7 +2320,7 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dev": true,
       "requires": {
-        "buffer": "5.2.1"
+        "buffer": "^5.1.0"
       }
     },
     "crc32-stream": {
@@ -2329,8 +2329,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.8.0",
-        "readable-stream": "2.3.6"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       }
     },
     "cson-parser": {
@@ -2339,7 +2339,7 @@
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.12.7"
+        "coffee-script": "^1.10.0"
       },
       "dependencies": {
         "coffee-script": {
@@ -2356,7 +2356,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cwd": {
@@ -2364,7 +2364,7 @@
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
       "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
       "requires": {
-        "find-pkg": "0.1.2"
+        "find-pkg": "^0.1.0"
       }
     },
     "dashdash": {
@@ -2374,27 +2374,27 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-store": {
       "version": "0.16.1",
-      "resolved": "http://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
       "integrity": "sha1-5pwDpcrBXR/zPwJUyWeDZT5ogwQ=",
       "requires": {
-        "cache-base": "0.8.5",
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "graceful-fs": "4.1.11",
-        "has-own-deep": "0.1.4",
-        "lazy-cache": "2.0.2",
-        "mkdirp": "0.5.1",
-        "project-name": "0.2.6",
-        "resolve-dir": "0.1.1",
-        "rimraf": "2.6.2",
-        "union-value": "0.2.4"
+        "cache-base": "^0.8.4",
+        "clone-deep": "^0.2.4",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "graceful-fs": "^4.1.4",
+        "has-own-deep": "^0.1.4",
+        "lazy-cache": "^2.0.1",
+        "mkdirp": "^0.5.1",
+        "project-name": "^0.2.5",
+        "resolve-dir": "^0.1.0",
+        "rimraf": "^2.5.3",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "cache-base": {
@@ -2402,16 +2402,16 @@
           "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           }
         },
         "collection-visit": {
@@ -2419,9 +2419,9 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "isobject": {
@@ -2434,8 +2434,8 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -2443,7 +2443,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -2461,10 +2461,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -2472,10 +2472,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -2483,8 +2483,8 @@
           "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           }
         }
       }
@@ -2495,8 +2495,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -2528,7 +2528,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-bind": {
@@ -2536,7 +2536,7 @@
       "resolved": "https://registry.npmjs.org/deep-bind/-/deep-bind-0.3.0.tgz",
       "integrity": "sha1-lcMd2Eoc0bOBEZosQu25DbSFvDM=",
       "requires": {
-        "mixin-deep": "1.3.1"
+        "mixin-deep": "^1.1.3"
       }
     },
     "deep-extend": {
@@ -2551,7 +2551,7 @@
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "requires": {
-        "kind-of": "5.1.0"
+        "kind-of": "^5.0.2"
       }
     },
     "defaults-deep": {
@@ -2559,9 +2559,9 @@
       "resolved": "https://registry.npmjs.org/defaults-deep/-/defaults-deep-0.2.4.tgz",
       "integrity": "sha512-V6BtqzcMvn0EPOy7f+SfMhfmTawq+7UQdt9yZH0EBK89+IHo5f+Hse/qzTorAXOBrQpxpwb6cB/8OgtaMrT+Fg==",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1",
-        "lazy-cache": "0.2.7"
+        "for-own": "^0.1.3",
+        "is-extendable": "^0.1.1",
+        "lazy-cache": "^0.2.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -2576,7 +2576,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "requires": {
-        "is-descriptor": "0.1.6"
+        "is-descriptor": "^0.1.0"
       }
     },
     "delayed-stream": {
@@ -2596,8 +2596,8 @@
       "resolved": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-2.0.0.tgz",
       "integrity": "sha1-DQ9vYdmRVZH9Qwh6jpWF0+IRWnU=",
       "requires": {
-        "extend-shallow": "1.1.4",
-        "isobject": "2.1.0"
+        "extend-shallow": "^1.1.2",
+        "isobject": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2605,7 +2605,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -2624,7 +2624,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -2632,10 +2632,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -2645,8 +2645,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "empty-dir": {
@@ -2654,7 +2654,7 @@
       "resolved": "https://registry.npmjs.org/empty-dir/-/empty-dir-0.2.1.tgz",
       "integrity": "sha1-gJ7kih60rRy1EMJXLWb9DthNAas=",
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "^0.1.0"
       }
     },
     "en-route": {
@@ -2662,12 +2662,12 @@
       "resolved": "https://registry.npmjs.org/en-route/-/en-route-0.7.5.tgz",
       "integrity": "sha1-6CMOc4NsXpXGdX4EQtPBExJL3Zg=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "path-to-regexp": "1.7.0"
+        "arr-flatten": "^1.0.1",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "path-to-regexp": "^1.2.1"
       },
       "dependencies": {
         "kind-of": {
@@ -2675,7 +2675,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -2690,7 +2690,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine": {
@@ -2698,13 +2698,13 @@
       "resolved": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
       "integrity": "sha1-+H6MkLuAzT9YWXrFaVk+5G2idC0=",
       "requires": {
-        "assign-deep": "0.4.7",
-        "collection-visit": "0.2.3",
-        "get-value": "1.3.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "object.omit": "2.0.1",
-        "set-value": "0.2.0"
+        "assign-deep": "^0.4.3",
+        "collection-visit": "^0.2.0",
+        "get-value": "^1.2.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "object.omit": "^2.0.0",
+        "set-value": "^0.2.0"
       },
       "dependencies": {
         "collection-visit": {
@@ -2712,9 +2712,9 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -2722,7 +2722,7 @@
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -2732,10 +2732,10 @@
           "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
           "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "is-extendable": "0.1.1",
-            "lazy-cache": "0.2.7",
-            "noncharacters": "1.1.0"
+            "arr-flatten": "^1.0.1",
+            "is-extendable": "^0.1.1",
+            "lazy-cache": "^0.2.4",
+            "noncharacters": "^1.1.0"
           }
         },
         "kind-of": {
@@ -2743,7 +2743,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -2756,8 +2756,8 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -2765,7 +2765,7 @@
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -2775,7 +2775,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -2783,8 +2783,8 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
           "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
           "requires": {
-            "isobject": "1.0.2",
-            "noncharacters": "1.1.0"
+            "isobject": "^1.0.0",
+            "noncharacters": "^1.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -2801,14 +2801,14 @@
       "resolved": "https://registry.npmjs.org/engine-base/-/engine-base-0.1.3.tgz",
       "integrity": "sha1-1ZycxS591t0rSa579ftEmU9wFqU=",
       "requires": {
-        "component-emitter": "1.2.1",
-        "delimiter-regex": "2.0.0",
-        "engine": "0.1.12",
-        "engine-utils": "0.1.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "object.omit": "2.0.1",
-        "object.pick": "1.3.0"
+        "component-emitter": "^1.2.1",
+        "delimiter-regex": "^2.0.0",
+        "engine": "^0.1.12",
+        "engine-utils": "^0.1.1",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.1.3",
+        "object.omit": "^2.0.1",
+        "object.pick": "^1.2.0"
       }
     },
     "engine-cache": {
@@ -2816,12 +2816,12 @@
       "resolved": "https://registry.npmjs.org/engine-cache/-/engine-cache-0.19.4.tgz",
       "integrity": "sha1-giSWb732pl54Dsed+HtrLLgjlbI=",
       "requires": {
-        "async-helpers": "0.3.17",
-        "extend-shallow": "2.0.1",
-        "helper-cache": "0.7.2",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1"
+        "async-helpers": "^0.3.9",
+        "extend-shallow": "^2.0.1",
+        "helper-cache": "^0.7.2",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "isobject": {
@@ -2842,7 +2842,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "error-symbol": {
@@ -2882,13 +2882,13 @@
       "resolved": "https://registry.npmjs.org/expand-args/-/expand-args-0.4.3.tgz",
       "integrity": "sha1-OoZiJBxYF1fIzTf7d2d6xgL/nZg=",
       "requires": {
-        "expand-object": "0.4.2",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "minimist": "1.2.0",
-        "mixin-deep": "1.3.1",
-        "omit-empty": "0.4.1",
-        "set-value": "0.3.3"
+        "expand-object": "^0.4.2",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "set-value": "^0.3.3"
       },
       "dependencies": {
         "kind-of": {
@@ -2896,7 +2896,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "minimist": {
@@ -2911,7 +2911,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-object": {
@@ -2919,10 +2919,10 @@
       "resolved": "https://registry.npmjs.org/expand-object/-/expand-object-0.4.2.tgz",
       "integrity": "sha1-t/J+9pwv3MYrD5OQwMtHvAa7Buo=",
       "requires": {
-        "get-stdin": "5.0.1",
-        "is-number": "2.1.0",
-        "minimist": "1.2.0",
-        "set-value": "0.3.3"
+        "get-stdin": "^5.0.1",
+        "is-number": "^2.1.0",
+        "minimist": "^1.2.0",
+        "set-value": "^0.3.3"
       },
       "dependencies": {
         "minimist": {
@@ -2937,20 +2937,20 @@
       "resolved": "https://registry.npmjs.org/expand-pkg/-/expand-pkg-0.1.9.tgz",
       "integrity": "sha512-Qqtqzx/e8tODrDr0H8HtO7+nftN0wH9bsk3948KpKBZLrc86Cm3/8mRKJmDfNSDWWcuKsilMmFlKPhYx5gHYuA==",
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "defaults-deep": "0.2.4",
-        "export-files": "2.1.1",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "load-pkg": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "normalize-pkg": "0.3.20",
-        "omit-empty": "0.4.1",
-        "parse-author": "1.0.0",
-        "parse-git-config": "1.1.1",
-        "repo-utils": "0.3.7"
+        "component-emitter": "^1.2.1",
+        "debug": "^2.4.1",
+        "defaults-deep": "^0.2.4",
+        "export-files": "^2.1.1",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "load-pkg": "^3.0.1",
+        "mixin-deep": "^1.1.3",
+        "normalize-pkg": "^0.3.20",
+        "omit-empty": "^0.4.1",
+        "parse-author": "^1.0.0",
+        "parse-git-config": "^1.1.1",
+        "repo-utils": "^0.3.7"
       },
       "dependencies": {
         "kind-of": {
@@ -2958,7 +2958,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2968,7 +2968,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -2983,7 +2983,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "export-files": {
@@ -2991,7 +2991,7 @@
       "resolved": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
       "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
       "requires": {
-        "lazy-cache": "1.0.4"
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3011,7 +3011,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "extglob": {
@@ -3019,7 +3019,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -3040,7 +3040,7 @@
       "resolved": "https://registry.npmjs.org/falsey/-/falsey-0.3.2.tgz",
       "integrity": "sha512-lxEuefF5MBIVDmE6XeqCdM4BWk1+vYmGZtkbKZ/VFcg6uBBw6fXNEbWmxCjDdQlFc9hy450nkiWwM3VAW6G1qg==",
       "requires": {
-        "kind-of": "5.1.0"
+        "kind-of": "^5.0.2"
       }
     },
     "fast-deep-equal": {
@@ -3062,8 +3062,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-contents": {
@@ -3071,13 +3071,13 @@
       "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
       "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-stat": "0.1.3",
-        "graceful-fs": "4.1.11",
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1",
-        "lazy-cache": "0.2.7",
-        "through2": "2.0.3"
+        "extend-shallow": "^2.0.0",
+        "file-stat": "^0.1.0",
+        "graceful-fs": "^4.1.2",
+        "is-buffer": "^1.1.0",
+        "is-utf8": "^0.2.0",
+        "lazy-cache": "^0.2.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3092,8 +3092,8 @@
       "resolved": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
       "integrity": "sha1-XkGAbRvK5FjI/sMv484SLbu8Q1Y=",
       "requires": {
-        "is-binary-buffer": "1.0.0",
-        "isobject": "3.0.1"
+        "is-binary-buffer": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -3113,9 +3113,9 @@
       "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
       "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "lazy-cache": "0.2.7",
-        "through2": "2.0.3"
+        "graceful-fs": "^4.1.2",
+        "lazy-cache": "^0.2.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3141,11 +3141,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "3.1.0",
-        "repeat-element": "1.1.3",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-file-up": {
@@ -3153,8 +3153,8 @@
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
       "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
       "requires": {
-        "fs-exists-sync": "0.1.0",
-        "resolve-dir": "0.1.1"
+        "fs-exists-sync": "^0.1.0",
+        "resolve-dir": "^0.1.0"
       }
     },
     "find-pkg": {
@@ -3162,7 +3162,7 @@
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
       "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
       "requires": {
-        "find-file-up": "0.1.3"
+        "find-file-up": "^0.1.2"
       }
     },
     "find-up": {
@@ -3171,8 +3171,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -3181,7 +3181,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       }
     },
     "first-chunk-stream": {
@@ -3195,7 +3195,7 @@
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -3219,7 +3219,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -3236,9 +3236,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
+        "mime-types": "^2.1.12"
       }
     },
     "fs-constants": {
@@ -3263,10 +3263,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "gauge": {
@@ -3275,14 +3275,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "get-stdin": {
@@ -3300,8 +3300,8 @@
       "resolved": "https://registry.npmjs.org/get-view/-/get-view-0.1.3.tgz",
       "integrity": "sha1-NmCsBYuhPfl0nKvKpry5bUGqDqA=",
       "requires": {
-        "isobject": "3.0.1",
-        "match-file": "0.2.2"
+        "isobject": "^3.0.0",
+        "match-file": "^0.2.1"
       },
       "dependencies": {
         "isobject": {
@@ -3324,7 +3324,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-config-path": {
@@ -3332,9 +3332,9 @@
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "homedir-polyfill": "1.0.1"
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "homedir-polyfill": "^1.0.0"
       }
     },
     "git-repo-name": {
@@ -3342,10 +3342,10 @@
       "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
       "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
       "requires": {
-        "cwd": "0.9.1",
-        "file-name": "0.1.0",
-        "lazy-cache": "1.0.4",
-        "remote-origin-url": "0.5.3"
+        "cwd": "^0.9.1",
+        "file-name": "^0.1.0",
+        "lazy-cache": "^1.0.4",
+        "remote-origin-url": "^0.5.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3367,11 +3367,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3379,8 +3379,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -3388,7 +3388,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -3401,7 +3401,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -3411,8 +3411,8 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
     "glob-stream": {
@@ -3420,14 +3420,14 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "requires": {
-        "extend": "3.0.2",
-        "glob": "5.0.15",
-        "glob-parent": "3.1.0",
-        "micromatch": "2.3.11",
-        "ordered-read-streams": "0.3.0",
-        "through2": "0.6.5",
-        "to-absolute-glob": "0.1.1",
-        "unique-stream": "2.2.1"
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -3437,13 +3437,13 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3456,8 +3456,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -3467,8 +3467,8 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       },
       "dependencies": {
         "global-prefix": {
@@ -3476,10 +3476,10 @@
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "requires": {
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.5",
-            "is-windows": "0.2.0",
-            "which": "1.3.1"
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
           }
         },
         "is-windows": {
@@ -3494,11 +3494,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.1"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "graceful-fs": {
@@ -3511,10 +3511,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "js-yaml": "3.12.0",
-        "kind-of": "5.1.0",
-        "strip-bom-string": "1.0.0"
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.10.0",
+        "kind-of": "^5.0.2",
+        "strip-bom-string": "^1.0.0"
       },
       "dependencies": {
         "strip-bom-string": {
@@ -3529,12 +3529,12 @@
       "resolved": "https://registry.npmjs.org/group-array/-/group-array-0.3.3.tgz",
       "integrity": "sha1-u9nS9xjfS+M/D7kEMqrxtDYOSY8=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "for-own": "0.1.5",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "split-string": "1.0.1",
-        "union-value": "0.2.4"
+        "arr-flatten": "^1.0.1",
+        "for-own": "^0.1.4",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.1.0",
+        "split-string": "^1.0.1",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "kind-of": {
@@ -3542,7 +3542,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "set-value": {
@@ -3550,10 +3550,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "split-string": {
@@ -3561,7 +3561,7 @@
           "resolved": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz",
           "integrity": "sha1-vLqz9BUqzuOg1qskecDSh5w9s84=",
           "requires": {
-            "extend-shallow": "2.0.1"
+            "extend-shallow": "^2.0.1"
           }
         },
         "union-value": {
@@ -3569,10 +3569,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         }
       }
@@ -3583,23 +3583,23 @@
       "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
       "dev": true,
       "requires": {
-        "coffeescript": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.1",
-        "grunt-legacy-log": "2.0.0",
-        "grunt-legacy-util": "1.1.1",
-        "iconv-lite": "0.4.24",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
       },
       "dependencies": {
         "esprima": {
@@ -3614,12 +3614,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "grunt-cli": {
@@ -3628,10 +3628,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.1",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
         },
         "js-yaml": {
@@ -3640,8 +3640,8 @@
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
           }
         },
         "resolve": {
@@ -3652,18 +3652,46 @@
         }
       }
     },
+    "grunt-checktextdomain": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-checktextdomain/-/grunt-checktextdomain-1.0.1.tgz",
+      "integrity": "sha1-slTQHh3pEwBdTbHFMD2QI7mD4Zs=",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.2.1",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+          "integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.2.1",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.2.1.tgz",
+          "integrity": "sha1-dhPhV1FFshOGSD9/SFql/6jL0Qw=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~0.2.0",
+            "has-color": "~0.1.0"
+          }
+        }
+      }
+    },
     "grunt-contrib-compress": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.4.3.tgz",
       "integrity": "sha1-Ac7/ucY39S5wgfRjdQmD0KOw+nM=",
       "dev": true,
       "requires": {
-        "archiver": "1.3.0",
-        "chalk": "1.1.3",
-        "iltorb": "1.3.10",
-        "lodash": "4.17.10",
-        "pretty-bytes": "4.0.2",
-        "stream-buffers": "2.2.0"
+        "archiver": "^1.3.0",
+        "chalk": "^1.1.1",
+        "iltorb": "^1.0.13",
+        "lodash": "^4.7.0",
+        "pretty-bytes": "^4.0.2",
+        "stream-buffers": "^2.1.0"
       }
     },
     "grunt-contrib-copy": {
@@ -3672,8 +3700,8 @@
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1"
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
       }
     },
     "grunt-known-options": {
@@ -3688,10 +3716,10 @@
       "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "2.0.1",
-        "hooker": "0.2.3",
-        "lodash": "4.17.10"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
@@ -3700,8 +3728,8 @@
       "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "lodash": "4.17.10"
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3710,7 +3738,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3719,9 +3747,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -3730,7 +3758,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -3741,13 +3769,13 @@
       "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.17.10",
-        "underscore.string": "3.3.4",
-        "which": "1.3.1"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
       }
     },
     "grunt-phpcs": {
@@ -3763,9 +3791,9 @@
       "dev": true,
       "requires": {
         "applause": "1.2.2",
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1",
-        "lodash": "4.17.10"
+        "chalk": "^1.1.0",
+        "file-sync-cmp": "^0.1.0",
+        "lodash": "^4.11.0"
       }
     },
     "grunt-wptools": {
@@ -3774,7 +3802,7 @@
       "integrity": "sha512-ozHOTXwvppfFF3MoKosEFt4+gOmIFLbOjVxftLmUdGdDac+SG+DyE0WBXhYFGPJa7sT0ongo1sUHKpDveJwNGA==",
       "dev": true,
       "requires": {
-        "@ndc/wptools": "0.1.0"
+        "@ndc/wptools": "^0.1.0"
       }
     },
     "gulp-choose-files": {
@@ -3782,9 +3810,9 @@
       "resolved": "https://registry.npmjs.org/gulp-choose-files/-/gulp-choose-files-0.1.3.tgz",
       "integrity": "sha1-hrFfBjAHOrZz1XJb7sY+qhSFUPk=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "question-cache": "0.5.1",
-        "through2": "2.0.3"
+        "extend-shallow": "^2.0.1",
+        "question-cache": "^0.5.1",
+        "through2": "^2.0.1"
       }
     },
     "gulp-sourcemaps": {
@@ -3792,11 +3820,11 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
-        "convert-source-map": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
       }
     },
     "handy": {
@@ -3818,8 +3846,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -3827,8 +3855,14 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3841,7 +3875,7 @@
       "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
       "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -3854,7 +3888,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -3875,9 +3909,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
       "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "0.1.4",
-        "isobject": "2.1.0"
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
       },
       "dependencies": {
         "has-values": {
@@ -3892,8 +3926,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -3901,7 +3935,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3909,7 +3943,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -3919,7 +3953,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3929,9 +3963,9 @@
       "resolved": "https://registry.npmjs.org/helper-cache/-/helper-cache-0.7.2.tgz",
       "integrity": "sha1-AkVixLS4sqsqtTHQC+FuxJZRi5A=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "lodash.bind": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "lodash.bind": "^3.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3946,7 +3980,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hooker": {
@@ -3973,9 +4007,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -3984,7 +4018,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -4000,10 +4034,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "0.2.0",
-        "nan": "2.11.0",
-        "node-gyp": "3.8.0",
-        "prebuild-install": "2.5.3"
+        "detect-libc": "^0.2.0",
+        "nan": "^2.6.2",
+        "node-gyp": "^3.6.2",
+        "prebuild-install": "^2.3.0"
       }
     },
     "indent-string": {
@@ -4012,7 +4046,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflection": {
@@ -4025,8 +4059,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "info-symbol": {
@@ -4049,25 +4083,25 @@
       "resolved": "https://registry.npmjs.org/inquirer2/-/inquirer2-0.1.1.tgz",
       "integrity": "sha1-vFQkqBQ1fEHmXi6Vf+U2ruqb8fY=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "arr-flatten": "1.1.0",
-        "arr-pluck": "0.1.0",
-        "array-unique": "0.2.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "1.1.1",
-        "extend-shallow": "2.0.1",
-        "figures": "1.7.0",
-        "is-number": "2.1.0",
-        "is-plain-object": "2.0.4",
-        "lazy-cache": "1.0.4",
-        "lodash.where": "3.1.0",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "4.0.8",
-        "strip-color": "0.1.0",
-        "through2": "2.0.3"
+        "ansi-escapes": "^1.1.1",
+        "ansi-regex": "^2.0.0",
+        "arr-flatten": "^1.0.1",
+        "arr-pluck": "^0.1.0",
+        "array-unique": "^0.2.1",
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-width": "^1.1.0",
+        "extend-shallow": "^2.0.1",
+        "figures": "^1.4.0",
+        "is-number": "^2.1.0",
+        "is-plain-object": "^2.0.1",
+        "lazy-cache": "^1.0.3",
+        "lodash.where": "^3.1.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^4.0.7",
+        "strip-color": "^0.1.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -4082,8 +4116,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "^0.2.1",
+        "is-windows": "^0.2.0"
       },
       "dependencies": {
         "is-windows": {
@@ -4098,7 +4132,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4106,7 +4140,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4116,9 +4150,9 @@
       "resolved": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
       "integrity": "sha1-zBwvGG+FzyZQIgveNZ2GIYfUnLY=",
       "requires": {
-        "has-values": "0.1.4",
-        "is-primitive": "2.0.0",
-        "omit-empty": "0.4.1"
+        "has-values": "^0.1.4",
+        "is-primitive": "^2.0.0",
+        "omit-empty": "^0.4.1"
       },
       "dependencies": {
         "has-values": {
@@ -4144,7 +4178,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-buffer/-/is-binary-buffer-1.0.0.tgz",
       "integrity": "sha1-vGAxKQtly/eZudlQK1D9U3VSQAc=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "is-buffer": {
@@ -4158,7 +4192,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -4166,7 +4200,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4174,7 +4208,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4189,9 +4223,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       }
     },
     "is-dotfile": {
@@ -4204,7 +4238,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4223,7 +4257,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4231,7 +4265,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator": {
@@ -4244,7 +4278,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-number": {
@@ -4252,7 +4286,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4260,7 +4294,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4270,7 +4304,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -4295,8 +4329,8 @@
       "resolved": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
       "integrity": "sha1-HTRpd0GdZl4qxshAE1NWheb3b38=",
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "isobject": "^2.1.0"
       }
     },
     "is-relative": {
@@ -4304,7 +4338,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "^0.1.1"
       }
     },
     "is-stream": {
@@ -4324,7 +4358,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.0"
       }
     },
     "is-utf8": {
@@ -4337,10 +4371,10 @@
       "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
       "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
       "requires": {
-        "debug": "2.6.9",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.2.0",
-        "lazy-cache": "2.0.2"
+        "debug": "^2.2.0",
+        "is-registered": "^0.1.5",
+        "is-valid-instance": "^0.2.0",
+        "lazy-cache": "^2.0.1"
       }
     },
     "is-valid-glob": {
@@ -4353,8 +4387,8 @@
       "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
       "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
       "requires": {
-        "isobject": "2.1.0",
-        "pascalcase": "0.1.1"
+        "isobject": "^2.1.0",
+        "pascalcase": "^0.1.1"
       }
     },
     "is-whitespace": {
@@ -4397,8 +4431,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4427,7 +4461,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4465,10 +4499,10 @@
       "resolved": "https://registry.npmjs.org/layouts/-/layouts-0.11.0.tgz",
       "integrity": "sha1-xiDos8uI/IxJLbRTin3VQKTffyI=",
       "requires": {
-        "delimiter-regex": "1.3.1",
-        "falsey": "0.3.2",
-        "get-view": "0.1.3",
-        "lazy-cache": "1.0.4"
+        "delimiter-regex": "^1.3.1",
+        "falsey": "^0.3.0",
+        "get-view": "^0.1.1",
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "delimiter-regex": {
@@ -4476,7 +4510,7 @@
           "resolved": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-1.3.1.tgz",
           "integrity": "sha1-Y4XK4UAE28DBzY3//+uGPVGZnv8=",
           "requires": {
-            "extend-shallow": "1.1.4"
+            "extend-shallow": "^1.1.2"
           }
         },
         "extend-shallow": {
@@ -4484,7 +4518,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -4504,7 +4538,7 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "lazystream": {
@@ -4512,7 +4546,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.5"
       }
     },
     "load-helpers": {
@@ -4520,11 +4554,11 @@
       "resolved": "https://registry.npmjs.org/load-helpers/-/load-helpers-0.2.11.tgz",
       "integrity": "sha1-9L2LIYQ1wFLl4536dxMinVcepCM=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "matched": "0.4.4",
-        "resolve-dir": "0.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "matched": "^0.4.1",
+        "resolve-dir": "^0.1.0"
       },
       "dependencies": {
         "glob": {
@@ -4532,12 +4566,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "matched": {
@@ -4545,15 +4579,15 @@
           "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.3",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -4564,11 +4598,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "load-pkg": {
@@ -4576,7 +4610,7 @@
       "resolved": "https://registry.npmjs.org/load-pkg/-/load-pkg-3.0.1.tgz",
       "integrity": "sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=",
       "requires": {
-        "find-pkg": "0.1.2"
+        "find-pkg": "^0.1.0"
       }
     },
     "load-templates": {
@@ -4584,14 +4618,14 @@
       "resolved": "https://registry.npmjs.org/load-templates/-/load-templates-0.11.4.tgz",
       "integrity": "sha1-zyk977a1hg/1uMRJ2qHAx7tyjek=",
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "glob-parent": "2.0.0",
-        "has-glob": "0.1.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "matched": "0.4.4",
-        "to-file": "0.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "glob-parent": "^2.0.0",
+        "has-glob": "^0.1.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "matched": "^0.4.1",
+        "to-file": "^0.2.0"
       },
       "dependencies": {
         "glob": {
@@ -4599,12 +4633,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -4612,7 +4646,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -4625,7 +4659,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "matched": {
@@ -4633,15 +4667,15 @@
           "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.3",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -4662,10 +4696,10 @@
       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
       "requires": {
-        "lodash._baseisequal": "3.0.7",
-        "lodash._bindcallback": "3.0.1",
-        "lodash.isarray": "3.0.4",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._baseeach": {
@@ -4673,7 +4707,7 @@
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basefilter": {
@@ -4681,7 +4715,7 @@
       "resolved": "https://registry.npmjs.org/lodash._basefilter/-/lodash._basefilter-3.0.0.tgz",
       "integrity": "sha1-S3ZAPfDihtA9Xg9yle00QeEB0SE=",
       "requires": {
-        "lodash._baseeach": "3.0.4"
+        "lodash._baseeach": "^3.0.0"
       }
     },
     "lodash._baseisequal": {
@@ -4689,9 +4723,9 @@
       "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "requires": {
-        "lodash.isarray": "3.0.4",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2"
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._baseismatch": {
@@ -4699,7 +4733,7 @@
       "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
       "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
       "requires": {
-        "lodash._baseisequal": "3.0.7"
+        "lodash._baseisequal": "^3.0.0"
       }
     },
     "lodash._basematches": {
@@ -4707,8 +4741,8 @@
       "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
       "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
       "requires": {
-        "lodash._baseismatch": "3.1.3",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseismatch": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -4721,7 +4755,7 @@
       "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
       "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -4749,9 +4783,9 @@
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
       "integrity": "sha1-+V9IY419i7tYVPkIJmUnmZ+/pLs=",
       "requires": {
-        "lodash._createwrapper": "3.2.0",
-        "lodash._replaceholders": "3.0.0",
-        "lodash.restparam": "3.6.1"
+        "lodash._createwrapper": "^3.0.0",
+        "lodash._replaceholders": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash.filter": {
@@ -4799,9 +4833,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.last": {
@@ -4819,7 +4853,7 @@
       "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.restparam": {
@@ -4832,11 +4866,11 @@
       "resolved": "https://registry.npmjs.org/lodash.where/-/lodash.where-3.1.0.tgz",
       "integrity": "sha1-LnhLnJM2jV11qu4zLOF2Ai8rlVM=",
       "requires": {
-        "lodash._arrayfilter": "3.0.0",
-        "lodash._basecallback": "3.3.1",
-        "lodash._basefilter": "3.0.0",
-        "lodash._basematches": "3.2.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._arrayfilter": "^3.0.0",
+        "lodash._basecallback": "^3.0.0",
+        "lodash._basefilter": "^3.0.0",
+        "lodash._basematches": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "log-ok": {
@@ -4844,8 +4878,8 @@
       "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
       "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
       "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
+        "ansi-green": "^0.1.1",
+        "success-symbol": "^0.1.0"
       }
     },
     "log-utils": {
@@ -4853,13 +4887,13 @@
       "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "requires": {
-        "ansi-colors": "0.2.0",
-        "error-symbol": "0.1.0",
-        "info-symbol": "0.1.0",
-        "log-ok": "0.1.1",
-        "success-symbol": "0.1.0",
-        "time-stamp": "1.1.0",
-        "warning-symbol": "0.1.0"
+        "ansi-colors": "^0.2.0",
+        "error-symbol": "^0.1.0",
+        "info-symbol": "^0.1.0",
+        "log-ok": "^0.1.1",
+        "success-symbol": "^0.1.0",
+        "time-stamp": "^1.0.1",
+        "warning-symbol": "^0.1.0"
       }
     },
     "longest": {
@@ -4873,8 +4907,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -4887,7 +4921,7 @@
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4902,8 +4936,8 @@
       "resolved": "https://registry.npmjs.org/map-config/-/map-config-0.5.0.tgz",
       "integrity": "sha1-FwJgfiZ696NwyKnQxiumUk/rb+U=",
       "requires": {
-        "array-unique": "0.2.1",
-        "async": "1.5.2"
+        "array-unique": "^0.2.1",
+        "async": "^1.5.2"
       }
     },
     "map-obj": {
@@ -4917,26 +4951,26 @@
       "resolved": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
       "integrity": "sha1-wZVRg0/DwHoEWXt6WvtEpHWvlbQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "collection-visit": "0.2.3",
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "is-primitive": "2.0.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "longest": "1.0.1",
-        "mixin-deep": "1.3.1",
-        "object.omit": "2.0.1",
-        "object.pick": "1.3.0",
-        "omit-empty": "0.4.1",
-        "pad-right": "0.2.2",
-        "set-value": "0.4.3",
-        "sort-object-arrays": "0.1.1",
-        "union-value": "0.2.4"
+        "arr-union": "^3.1.0",
+        "collection-visit": "^0.2.3",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "is-primitive": "^2.0.0",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "log-utils": "^0.2.1",
+        "longest": "^1.0.1",
+        "mixin-deep": "^1.1.3",
+        "object.omit": "^2.0.1",
+        "object.pick": "^1.2.0",
+        "omit-empty": "^0.4.1",
+        "pad-right": "^0.2.2",
+        "set-value": "^0.4.0",
+        "sort-object-arrays": "^0.1.1",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "collection-visit": {
@@ -4944,9 +4978,9 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "kind-of": {
@@ -4954,7 +4988,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "map-visit": {
@@ -4962,8 +4996,8 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -4971,7 +5005,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -4979,10 +5013,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -4990,10 +5024,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         }
       }
@@ -5003,7 +5037,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "match-file": {
@@ -5011,9 +5045,9 @@
       "resolved": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz",
       "integrity": "sha1-Jua88bOQpmH2Em+visUB4z7M+uk=",
       "requires": {
-        "is-glob": "3.1.0",
-        "isobject": "3.0.1",
-        "micromatch": "2.3.11"
+        "is-glob": "^3.1.0",
+        "isobject": "^3.0.0",
+        "micromatch": "^2.3.11"
       },
       "dependencies": {
         "isobject": {
@@ -5028,12 +5062,12 @@
       "resolved": "https://registry.npmjs.org/matched/-/matched-1.0.2.tgz",
       "integrity": "sha512-7ivM1jFZVTOOS77QsR+TtYHH0ecdLclMkqbf5qiJdX2RorqfhsL65QHySPZgDE0ZjHoh+mQUNHTanNXIlzXd0Q==",
       "requires": {
-        "arr-union": "3.1.0",
-        "async-array-reduce": "0.2.1",
-        "glob": "7.1.3",
-        "has-glob": "1.0.0",
-        "is-valid-glob": "1.0.0",
-        "resolve-dir": "1.0.1"
+        "arr-union": "^3.1.0",
+        "async-array-reduce": "^0.2.1",
+        "glob": "^7.1.2",
+        "has-glob": "^1.0.0",
+        "is-valid-glob": "^1.0.0",
+        "resolve-dir": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -5041,12 +5075,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-modules": {
@@ -5054,9 +5088,9 @@
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.2",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
         },
         "has-glob": {
@@ -5064,7 +5098,7 @@
           "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "is-valid-glob": {
@@ -5077,8 +5111,8 @@
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         }
       }
@@ -5094,16 +5128,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -5119,9 +5153,9 @@
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
       "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
       "requires": {
-        "arr-union": "3.1.0",
-        "clone-deep": "0.2.4",
-        "kind-of": "3.2.2"
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5129,7 +5163,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5139,7 +5173,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge-value": {
@@ -5147,10 +5181,10 @@
       "resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
       "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
       "requires": {
-        "get-value": "2.0.6",
-        "is-extendable": "1.0.1",
-        "mixin-deep": "1.3.1",
-        "set-value": "2.0.0"
+        "get-value": "^2.0.6",
+        "is-extendable": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "set-value": "^2.0.0"
       },
       "dependencies": {
         "is-extendable": {
@@ -5158,7 +5192,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "set-value": {
@@ -5166,10 +5200,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -5186,19 +5220,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "dependencies": {
         "is-extglob": {
@@ -5211,7 +5245,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "kind-of": {
@@ -5219,7 +5253,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5236,7 +5270,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-response": {
@@ -5251,7 +5285,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5264,8 +5298,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5273,7 +5307,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5283,8 +5317,8 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -5341,7 +5375,7 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-abi": {
@@ -5351,7 +5385,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.4.1"
       }
     },
     "node-gyp": {
@@ -5361,18 +5395,18 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.88.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.1"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "glob": {
@@ -5382,12 +5416,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "semver": {
@@ -5417,7 +5451,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -5426,10 +5460,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -5437,7 +5471,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-pkg": {
@@ -5445,24 +5479,24 @@
       "resolved": "https://registry.npmjs.org/normalize-pkg/-/normalize-pkg-0.3.20.tgz",
       "integrity": "sha1-Luc3FJUXhQ2c7/WmI0r174nFFag=",
       "requires": {
-        "arr-union": "3.1.0",
-        "array-unique": "0.3.2",
-        "component-emitter": "1.2.1",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "map-schema": "0.2.4",
-        "minimist": "1.2.0",
-        "mixin-deep": "1.3.1",
-        "omit-empty": "0.4.1",
-        "parse-git-config": "1.1.1",
-        "repo-utils": "0.3.7",
-        "semver": "5.5.1",
-        "stringify-author": "0.1.3",
-        "write-json": "0.2.2"
+        "arr-union": "^3.1.0",
+        "array-unique": "^0.3.2",
+        "component-emitter": "^1.2.1",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.0.4",
+        "lazy-cache": "^2.0.1",
+        "map-schema": "^0.2.3",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "parse-git-config": "^1.0.2",
+        "repo-utils": "^0.3.6",
+        "semver": "^5.3.0",
+        "stringify-author": "^0.1.3",
+        "write-json": "^0.2.2"
       },
       "dependencies": {
         "array-unique": {
@@ -5475,7 +5509,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "minimist": {
@@ -5490,7 +5524,7 @@
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-0.0.6.tgz",
       "integrity": "sha1-GKFNw/xJXcBs++Ao8AvhbdrE+uo=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "npm": {
@@ -5499,124 +5533,124 @@
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "abbrev": "1.1.1",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.2",
-        "bluebird": "3.5.1",
-        "byte-size": "4.0.3",
-        "cacache": "11.2.0",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "ci-info": "1.4.0",
-        "cli-columns": "3.1.2",
-        "cli-table3": "0.5.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "figgy-pudding": "3.4.1",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.7.1",
-        "iferr": "1.0.2",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "2.0.6",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "2.0.2",
-        "libnpmhook": "4.0.1",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.0.2",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.3",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.8.0",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.3.1",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.1.0",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.1.11",
-        "npm-pick-manifest": "2.1.0",
-        "npm-profile": "3.0.2",
-        "npm-registry-client": "8.6.0",
-        "npm-registry-fetch": "1.1.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.5.0",
-        "osenv": "0.1.5",
-        "pacote": "8.1.6",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.2.1",
-        "readable-stream": "2.3.6",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.88.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "6.0.0",
-        "stringify-package": "1.0.0",
-        "tar": "4.4.6",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.4",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.2",
+        "bluebird": "~3.5.1",
+        "byte-size": "^4.0.3",
+        "cacache": "^11.2.0",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "ci-info": "^1.4.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.4.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.7.1",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^2.0.6",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^2.0.2",
+        "libnpmhook": "^4.0.1",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.3",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.8.0",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.3.1",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.11",
+        "npm-pick-manifest": "^2.1.0",
+        "npm-profile": "^3.0.2",
+        "npm-registry-client": "^8.6.0",
+        "npm-registry-fetch": "^1.1.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.0",
+        "osenv": "^0.1.5",
+        "pacote": "^8.1.6",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^2.3.6",
+        "readdir-scoped-modules": "*",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.0",
+        "stringify-package": "^1.0.0",
+        "tar": "^4.4.6",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.3.2",
-        "validate-npm-package-license": "3.0.4",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.1",
-        "worker-farm": "1.6.0",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.2",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.6.0",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -5624,8 +5658,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "abbrev": {
@@ -5638,7 +5672,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
@@ -5646,7 +5680,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "humanize-ms": "1.2.1"
+            "humanize-ms": "^1.2.1"
           }
         },
         "ajv": {
@@ -5654,10 +5688,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-align": {
@@ -5665,7 +5699,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
@@ -5678,7 +5712,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
@@ -5706,8 +5740,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asap": {
@@ -5720,7 +5754,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
@@ -5754,7 +5788,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
@@ -5762,11 +5796,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "write-file-atomic": "2.3.0"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "block-stream": {
@@ -5774,7 +5808,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "bluebird": {
@@ -5787,13 +5821,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.4.1",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "2.0.0"
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
           }
         },
         "brace-expansion": {
@@ -5801,7 +5835,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5835,20 +5869,20 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "figgy-pudding": "3.4.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.3",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.0",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "figgy-pudding": "^3.1.0",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.0",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           }
         },
         "call-limit": {
@@ -5876,9 +5910,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "chownr": {
@@ -5896,7 +5930,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-regex": "2.1.0"
+            "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
@@ -5909,8 +5943,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           }
         },
         "cli-table3": {
@@ -5918,9 +5952,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "1.1.2",
-            "object-assign": "4.1.1",
-            "string-width": "2.1.1"
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
           }
         },
         "cliui": {
@@ -5928,9 +5962,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -5943,7 +5977,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -5958,8 +5992,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "co": {
@@ -5977,7 +6011,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -5996,8 +6030,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           }
         },
         "combined-stream": {
@@ -6005,7 +6039,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -6018,10 +6052,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "config-chain": {
@@ -6029,8 +6063,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           }
         },
         "configstore": {
@@ -6038,12 +6072,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.3.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "console-control-strings": {
@@ -6056,12 +6090,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-write-stream-atomic": "1.0.10",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           },
           "dependencies": {
             "iferr": {
@@ -6081,7 +6115,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "capture-stack-trace": "1.0.0"
+            "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
@@ -6089,9 +6123,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.3",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "crypto-random-string": {
@@ -6109,7 +6143,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -6152,7 +6186,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "clone": "1.0.4"
+            "clone": "^1.0.2"
           }
         },
         "delayed-stream": {
@@ -6180,8 +6214,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asap": "2.0.6",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           }
         },
         "dot-prop": {
@@ -6189,7 +6223,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
@@ -6207,10 +6241,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -6219,8 +6253,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2"
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "editor": {
@@ -6233,7 +6267,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.23"
+            "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
@@ -6241,7 +6275,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "err-code": {
@@ -6254,7 +6288,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "es6-promise": {
@@ -6267,7 +6301,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promise": "4.2.4"
+            "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
@@ -6280,13 +6314,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "extend": {
@@ -6324,7 +6358,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "flush-write-stream": {
@@ -6332,8 +6366,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
           }
         },
         "forever-agent": {
@@ -6346,9 +6380,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
+            "mime-types": "^2.1.12"
           }
         },
         "from2": {
@@ -6356,8 +6390,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
           }
         },
         "fs-minipass": {
@@ -6365,7 +6399,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.3.3"
+            "minipass": "^2.2.1"
           }
         },
         "fs-vacuum": {
@@ -6373,9 +6407,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
@@ -6383,10 +6417,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           },
           "dependencies": {
             "iferr": {
@@ -6406,10 +6440,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "gauge": {
@@ -6417,14 +6451,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -6432,9 +6466,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -6449,14 +6483,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -6481,7 +6515,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -6489,12 +6523,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-dirs": {
@@ -6502,7 +6536,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.5"
+            "ini": "^1.3.4"
           }
         },
         "got": {
@@ -6510,17 +6544,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -6538,8 +6572,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has-flag": {
@@ -6567,7 +6601,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.2.0",
+            "agent-base": "4",
             "debug": "3.1.0"
           }
         },
@@ -6576,9 +6610,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -6586,8 +6620,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.2.0",
-            "debug": "3.1.0"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           }
         },
         "humanize-ms": {
@@ -6595,7 +6629,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
@@ -6603,7 +6637,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
@@ -6616,7 +6650,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
@@ -6634,8 +6668,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -6653,14 +6687,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.4",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -6683,7 +6717,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-ci": {
@@ -6691,7 +6725,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ci-info": "1.4.0"
+            "ci-info": "^1.0.0"
           }
         },
         "is-cidr": {
@@ -6699,7 +6733,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "2.0.9"
+            "cidr-regex": "^2.0.8"
           }
         },
         "is-fullwidth-code-point": {
@@ -6707,7 +6741,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-installed-globally": {
@@ -6715,8 +6749,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "global-dirs": "0.1.1",
-            "is-path-inside": "1.0.1"
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-npm": {
@@ -6734,7 +6768,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
@@ -6819,7 +6853,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "package-json": "4.0.1"
+            "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
@@ -6832,7 +6866,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "libcipm": {
@@ -6840,20 +6874,20 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bin-links": "1.1.2",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.2",
-            "mkdirp": "0.5.1",
-            "npm-lifecycle": "2.1.0",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.0",
-            "pacote": "8.1.6",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.6.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^2.0.3",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^8.1.6",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
           }
         },
         "libnpmhook": {
@@ -6861,8 +6895,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.4.1",
-            "npm-registry-fetch": "3.1.1"
+            "figgy-pudding": "^3.1.0",
+            "npm-registry-fetch": "^3.0.0"
           },
           "dependencies": {
             "npm-registry-fetch": {
@@ -6870,11 +6904,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "figgy-pudding": "3.4.1",
-                "lru-cache": "4.1.3",
-                "make-fetch-happen": "4.0.1",
-                "npm-package-arg": "6.1.0"
+                "bluebird": "^3.5.1",
+                "figgy-pudding": "^3.1.0",
+                "lru-cache": "^4.1.2",
+                "make-fetch-happen": "^4.0.0",
+                "npm-package-arg": "^6.0.0"
               }
             }
           }
@@ -6884,14 +6918,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.1",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           }
         },
         "locate-path": {
@@ -6899,8 +6933,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lock-verify": {
@@ -6908,8 +6942,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
@@ -6917,7 +6951,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -6930,8 +6964,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           }
         },
         "lodash._bindcallback": {
@@ -6949,7 +6983,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
@@ -7002,8 +7036,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "make-dir": {
@@ -7011,7 +7045,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
@@ -7019,17 +7053,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "3.4.1",
-            "cacache": "11.2.0",
-            "http-cache-semantics": "3.8.1",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.1",
-            "lru-cache": "4.1.3",
-            "mississippi": "3.0.0",
-            "node-fetch-npm": "2.0.2",
-            "promise-retry": "1.1.1",
-            "socks-proxy-agent": "4.0.1",
-            "ssri": "6.0.0"
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^11.0.1",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^4.1.2",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
           }
         },
         "meant": {
@@ -7042,7 +7076,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "mime-db": {
@@ -7055,7 +7089,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.35.0"
+            "mime-db": "~1.35.0"
           }
         },
         "mimic-fn": {
@@ -7068,7 +7102,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -7081,8 +7115,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           },
           "dependencies": {
             "yallist": {
@@ -7097,7 +7131,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.3.3"
+            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -7105,16 +7139,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.6.0",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.3",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "mkdirp": {
@@ -7130,12 +7164,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           }
         },
         "ms": {
@@ -7153,9 +7187,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "0.1.12",
-            "json-parse-better-errors": "1.0.2",
-            "safe-buffer": "5.1.2"
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "node-gyp": {
@@ -7163,18 +7197,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.88.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.1"
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "nopt": {
@@ -7182,7 +7216,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -7195,9 +7229,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             }
           }
@@ -7207,8 +7241,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
@@ -7216,10 +7250,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.4"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-audit-report": {
@@ -7227,8 +7261,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-table3": "0.5.0",
-            "console-control-strings": "1.1.0"
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
           }
         },
         "npm-bundled": {
@@ -7246,7 +7280,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
@@ -7254,14 +7288,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.8.0",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.8.0",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.1"
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -7274,10 +7308,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
@@ -7285,8 +7319,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.5"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
@@ -7294,8 +7328,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
           }
         },
         "npm-profile": {
@@ -7303,8 +7337,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "4.0.1"
+            "aproba": "^1.1.2 || 2",
+            "make-fetch-happen": "^2.5.0 || 3 || 4"
           }
         },
         "npm-registry-client": {
@@ -7312,18 +7346,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.88.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.3.0"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "retry": {
@@ -7336,7 +7370,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -7346,12 +7380,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.3",
-            "make-fetch-happen": "3.0.0",
-            "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.2"
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^2.0.1",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^3.0.0",
+            "npm-package-arg": "^6.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "cacache": {
@@ -7359,19 +7393,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.3",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
               },
               "dependencies": {
                 "mississippi": {
@@ -7379,16 +7413,16 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "concat-stream": "1.6.2",
-                    "duplexify": "3.6.0",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.3",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "2.0.1",
-                    "pumpify": "1.5.1",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^2.0.1",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   }
                 }
               }
@@ -7403,17 +7437,17 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.3",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^10.0.4",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.2.4"
               }
             },
             "pump": {
@@ -7421,8 +7455,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "smart-buffer": {
@@ -7435,8 +7469,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ip": "1.1.5",
-                "smart-buffer": "1.1.15"
+                "ip": "^1.1.4",
+                "smart-buffer": "^1.0.13"
               }
             },
             "socks-proxy-agent": {
@@ -7444,8 +7478,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "agent-base": "4.2.0",
-                "socks": "1.1.10"
+                "agent-base": "^4.1.0",
+                "socks": "^1.1.10"
               }
             },
             "ssri": {
@@ -7453,7 +7487,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -7463,7 +7497,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -7476,10 +7510,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -7502,7 +7536,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -7520,9 +7554,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "os-tmpdir": {
@@ -7535,8 +7569,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-finally": {
@@ -7549,7 +7583,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -7557,7 +7591,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -7570,10 +7604,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.2",
-            "registry-url": "3.1.0",
-            "semver": "5.5.0"
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "pacote": {
@@ -7581,31 +7615,31 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "11.2.0",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.3",
-            "make-fetch-happen": "4.0.1",
-            "minimatch": "3.0.4",
-            "minipass": "2.3.3",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.1.11",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "6.0.0",
-            "tar": "4.4.6",
-            "unique-filename": "1.1.0",
-            "which": "1.3.1"
+            "bluebird": "^3.5.1",
+            "cacache": "^11.0.2",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.5.0",
+            "ssri": "^6.0.0",
+            "tar": "^4.4.3",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           }
         },
         "parallel-transform": {
@@ -7613,9 +7647,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cyclist": "0.2.2",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
           }
         },
         "path-exists": {
@@ -7668,8 +7702,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "err-code": "1.1.2",
-            "retry": "0.10.1"
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
           },
           "dependencies": {
             "retry": {
@@ -7684,7 +7718,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "1.0.7"
+            "read": "1"
           }
         },
         "proto-list": {
@@ -7697,7 +7731,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "genfun": "4.0.1"
+            "genfun": "^4.0.1"
           }
         },
         "prr": {
@@ -7720,8 +7754,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "pumpify": {
@@ -7729,9 +7763,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "duplexify": "3.6.0",
-            "inherits": "2.0.3",
-            "pump": "2.0.1"
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
           },
           "dependencies": {
             "pump": {
@@ -7739,8 +7773,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             }
           }
@@ -7765,8 +7799,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
           }
         },
         "qw": {
@@ -7779,10 +7813,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -7797,7 +7831,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
@@ -7805,7 +7839,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
@@ -7813,13 +7847,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           }
         },
         "read-package-json": {
@@ -7827,11 +7861,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.2",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           }
         },
         "read-package-tree": {
@@ -7839,11 +7873,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -7851,13 +7885,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -7865,10 +7899,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "registry-auth-token": {
@@ -7876,8 +7910,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.7",
-            "safe-buffer": "5.1.2"
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
           }
         },
         "registry-url": {
@@ -7885,7 +7919,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.7"
+            "rc": "^1.0.1"
           }
         },
         "request": {
@@ -7893,26 +7927,26 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.19",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "require-directory": {
@@ -7940,7 +7974,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "run-queue": {
@@ -7948,7 +7982,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0"
+            "aproba": "^1.1.1"
           }
         },
         "safe-buffer": {
@@ -7971,7 +8005,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^5.0.3"
           }
         },
         "set-blocking": {
@@ -7984,8 +8018,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "shebang-command": {
@@ -7993,7 +8027,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -8026,8 +8060,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "4.0.1"
+            "ip": "^1.1.5",
+            "smart-buffer": "^4.0.1"
           }
         },
         "socks-proxy-agent": {
@@ -8035,8 +8069,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.2.0",
-            "socks": "2.2.0"
+            "agent-base": "~4.2.0",
+            "socks": "~2.2.0"
           }
         },
         "sorted-object": {
@@ -8049,8 +8083,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
@@ -8058,8 +8092,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               }
             },
             "isarray": {
@@ -8072,10 +8106,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -8090,8 +8124,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -8104,8 +8138,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -8118,15 +8152,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asn1": "0.2.4",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.2",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.2",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "ssri": {
@@ -8139,8 +8173,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-iterate": {
@@ -8148,8 +8182,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-shift": {
@@ -8167,8 +8201,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8186,7 +8220,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -8196,7 +8230,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -8209,7 +8243,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
@@ -8227,7 +8261,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tar": {
@@ -8235,13 +8269,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.3",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -8256,7 +8290,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0"
+            "execa": "^0.7.0"
           }
         },
         "text-table": {
@@ -8274,8 +8308,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "timed-out": {
@@ -8293,8 +8327,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -8302,7 +8336,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -8331,7 +8365,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
@@ -8339,7 +8373,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "^0.1.4"
           }
         },
         "unique-string": {
@@ -8347,7 +8381,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "crypto-random-string": "1.0.0"
+            "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
@@ -8365,16 +8399,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "url-parse-lax": {
@@ -8382,7 +8416,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
@@ -8405,8 +8439,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "validate-npm-package-name": {
@@ -8414,7 +8448,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           }
         },
         "verror": {
@@ -8422,9 +8456,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wcwidth": {
@@ -8432,7 +8466,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "defaults": "1.0.3"
+            "defaults": "^1.0.3"
           }
         },
         "which": {
@@ -8440,7 +8474,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -8453,7 +8487,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           },
           "dependencies": {
             "string-width": {
@@ -8461,9 +8495,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -8473,7 +8507,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
@@ -8481,7 +8515,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
@@ -8489,8 +8523,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -8498,9 +8532,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -8515,9 +8549,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           }
         },
         "xdg-basedir": {
@@ -8545,18 +8579,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -8571,7 +8605,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -8582,10 +8616,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -8610,9 +8644,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -8620,7 +8654,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8630,7 +8664,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -8645,8 +8679,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -8654,7 +8688,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8669,9 +8703,9 @@
       "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
       "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
       "requires": {
-        "has-values": "0.1.4",
-        "kind-of": "3.2.2",
-        "reduce-object": "0.1.3"
+        "has-values": "^0.1.4",
+        "kind-of": "^3.0.3",
+        "reduce-object": "^0.1.3"
       },
       "dependencies": {
         "has-values": {
@@ -8684,7 +8718,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8694,7 +8728,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -8707,8 +8741,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "option-cache": {
@@ -8716,15 +8750,15 @@
       "resolved": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
       "integrity": "sha1-y3ZRVboqhhwRCf8m4qIOqgZhKys=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "0.3.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "set-value": "0.4.3",
-        "to-object-path": "0.3.0"
+        "arr-flatten": "^1.0.3",
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^0.3.1",
+        "kind-of": "^3.2.2",
+        "lazy-cache": "^2.0.2",
+        "set-value": "^0.4.3",
+        "to-object-path": "^0.3.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8732,7 +8766,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "set-value": {
@@ -8740,10 +8774,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -8753,8 +8787,8 @@
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
-        "is-stream": "1.1.0",
-        "readable-stream": "2.3.6"
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
       }
     },
     "os-homedir": {
@@ -8776,8 +8810,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "pad-right": {
@@ -8785,7 +8819,7 @@
       "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
       "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.2"
       }
     },
     "paginationator": {
@@ -8803,10 +8837,10 @@
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
       "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "git-config-path": "1.0.1",
-        "ini": "1.3.5"
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "git-config-path": "^1.0.1",
+        "ini": "^1.3.4"
       }
     },
     "parse-github-url": {
@@ -8819,10 +8853,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -8835,7 +8869,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -8846,7 +8880,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -8859,13 +8893,13 @@
       "resolved": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.4.tgz",
       "integrity": "sha512-eqtUnI5+COkf1CQOYo8FmykN5Zs+5Yr60f/7GcPgQDZEEjdE/VZ4WMaMo9g37foof8h64t/TH2Uvk2Sq0fDy/g==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-is-binary": "1.0.0",
-        "gray-matter": "3.1.1",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "trim-leading-lines": "0.1.1"
+        "extend-shallow": "^2.0.1",
+        "file-is-binary": "^1.0.0",
+        "gray-matter": "^3.0.2",
+        "isobject": "^3.0.1",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.2.0",
+        "trim-leading-lines": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -8891,7 +8925,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -8925,9 +8959,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -8955,7 +8989,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-store": {
@@ -8963,11 +8997,11 @@
       "resolved": "https://registry.npmjs.org/pkg-store/-/pkg-store-0.2.2.tgz",
       "integrity": "sha1-sfXA+GIKWf1mWGrMXiVvTCw3oNg=",
       "requires": {
-        "cache-base": "0.8.5",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "union-value": "0.2.4",
-        "write-json": "0.2.2"
+        "cache-base": "^0.8.2",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "union-value": "^0.2.3",
+        "write-json": "^0.2.2"
       },
       "dependencies": {
         "cache-base": {
@@ -8975,16 +9009,16 @@
           "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           },
           "dependencies": {
             "lazy-cache": {
@@ -8992,7 +9026,7 @@
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -9002,9 +9036,9 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -9012,7 +9046,7 @@
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -9027,7 +9061,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -9040,8 +9074,8 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -9049,7 +9083,7 @@
               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -9059,7 +9093,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9077,10 +9111,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -9088,10 +9122,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -9099,8 +9133,8 @@
           "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           }
         }
       }
@@ -9112,21 +9146,21 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.3",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
         "detect-libc": {
@@ -9161,8 +9195,8 @@
       "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-0.2.0.tgz",
       "integrity": "sha1-ejvexAScYgzXxCt/NCt01W5z104=",
       "requires": {
-        "is-number": "2.1.0",
-        "nanoseconds": "0.1.0"
+        "is-number": "^2.0.2",
+        "nanoseconds": "^0.1.0"
       }
     },
     "process-nextick-args": {
@@ -9175,9 +9209,9 @@
       "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
       "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
       "requires": {
-        "find-pkg": "0.1.2",
-        "git-repo-name": "0.6.0",
-        "minimist": "1.2.0"
+        "find-pkg": "^0.1.2",
+        "git-repo-name": "^0.6.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -9201,8 +9235,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -9224,25 +9258,25 @@
       "resolved": "https://registry.npmjs.org/question-cache/-/question-cache-0.5.1.tgz",
       "integrity": "sha1-C8JzKRdTQXB99azTHvLd9nApFo0=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "arr-union": "3.1.0",
-        "async-each-series": "1.1.0",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "get-value": "2.0.6",
-        "has-value": "0.3.1",
-        "inquirer2": "0.1.1",
-        "is-answer": "0.1.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "omit-empty": "0.4.1",
-        "option-cache": "3.5.0",
-        "os-homedir": "1.0.2",
-        "project-name": "0.2.6",
-        "set-value": "0.3.3",
-        "to-choices": "0.2.0",
-        "use": "2.0.2"
+        "arr-flatten": "^1.0.1",
+        "arr-union": "^3.1.0",
+        "async-each-series": "^1.1.0",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "get-value": "^2.0.6",
+        "has-value": "^0.3.1",
+        "inquirer2": "^0.1.1",
+        "is-answer": "^0.1.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "option-cache": "^3.4.0",
+        "os-homedir": "^1.0.1",
+        "project-name": "^0.2.5",
+        "set-value": "^0.3.3",
+        "to-choices": "^0.2.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "use": {
@@ -9250,9 +9284,9 @@
           "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
           "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
           "requires": {
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2"
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.2"
           },
           "dependencies": {
             "isobject": {
@@ -9269,13 +9303,13 @@
       "resolved": "https://registry.npmjs.org/question-store/-/question-store-0.11.1.tgz",
       "integrity": "sha1-gf1NRF9NWtwqYiPCUj+nEj4E/X0=",
       "requires": {
-        "common-config": "0.1.0",
-        "data-store": "0.16.1",
-        "debug": "2.6.9",
-        "is-answer": "0.1.1",
-        "lazy-cache": "2.0.2",
-        "project-name": "0.2.6",
-        "question-cache": "0.5.1"
+        "common-config": "^0.1.0",
+        "data-store": "^0.16.1",
+        "debug": "^2.2.0",
+        "is-answer": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "project-name": "^0.2.6",
+        "question-cache": "^0.5.1"
       }
     },
     "randomatic": {
@@ -9283,9 +9317,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -9307,10 +9341,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -9333,9 +9367,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -9344,22 +9378,22 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -9367,8 +9401,8 @@
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -9378,8 +9412,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-object": {
@@ -9387,7 +9421,7 @@
       "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
       "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
       "requires": {
-        "for-own": "0.1.5"
+        "for-own": "^0.1.1"
       }
     },
     "regex-cache": {
@@ -9395,7 +9429,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "relative": {
@@ -9403,7 +9437,7 @@
       "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
       "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.0.0"
       }
     },
     "remote-origin-url": {
@@ -9411,7 +9445,7 @@
       "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz",
       "integrity": "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==",
       "requires": {
-        "parse-git-config": "1.1.1"
+        "parse-git-config": "^1.1.1"
       }
     },
     "remove-trailing-separator": {
@@ -9435,7 +9469,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -9448,18 +9482,18 @@
       "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
       "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "git-config-path": "1.0.1",
-        "is-absolute": "0.2.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "omit-empty": "0.4.1",
-        "parse-author": "1.0.0",
-        "parse-git-config": "1.1.1",
-        "parse-github-url": "0.3.2",
-        "project-name": "0.2.6"
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "git-config-path": "^1.0.1",
+        "is-absolute": "^0.2.6",
+        "kind-of": "^3.0.4",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "parse-author": "^1.0.0",
+        "parse-git-config": "^1.0.2",
+        "parse-github-url": "^0.3.2",
+        "project-name": "^0.2.6"
       },
       "dependencies": {
         "kind-of": {
@@ -9467,7 +9501,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -9479,26 +9513,26 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "resolve": {
@@ -9506,7 +9540,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -9514,8 +9548,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       },
       "dependencies": {
         "expand-tilde": {
@@ -9523,7 +9557,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.1"
           }
         }
       }
@@ -9533,14 +9567,14 @@
       "resolved": "https://registry.npmjs.org/resolve-file/-/resolve-file-0.2.2.tgz",
       "integrity": "sha1-FNvsWhnThPXW3GSin9ZigV0xdpY=",
       "requires": {
-        "cwd": "0.10.0",
-        "expand-tilde": "2.0.2",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "homedir-polyfill": "1.0.1",
-        "lazy-cache": "2.0.2",
-        "resolve": "1.8.1"
+        "cwd": "^0.10.0",
+        "expand-tilde": "^2.0.1",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.3",
+        "homedir-polyfill": "^1.0.0",
+        "lazy-cache": "^2.0.1",
+        "resolve": "^1.1.7"
       },
       "dependencies": {
         "cwd": {
@@ -9548,8 +9582,8 @@
           "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
           "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
           "requires": {
-            "find-pkg": "0.1.2",
-            "fs-exists-sync": "0.1.0"
+            "find-pkg": "^0.1.2",
+            "fs-exists-sync": "^0.1.0"
           }
         }
       }
@@ -9559,11 +9593,11 @@
       "resolved": "https://registry.npmjs.org/resolve-glob/-/resolve-glob-1.0.0.tgz",
       "integrity": "sha512-wSW9pVGJRs89k0wEXhM7C6+va9998NsDhgc0Y+6Nv8hrHsu0hUS7Ug10J1EiVtU6N2tKlSNvx9wLihL8Ao22Lg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-glob": "1.0.0",
-        "matched": "1.0.2",
-        "relative": "3.0.2",
-        "resolve-dir": "1.0.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-glob": "^1.0.0",
+        "matched": "^1.0.2",
+        "relative": "^3.0.2",
+        "resolve-dir": "^1.0.0"
       },
       "dependencies": {
         "global-modules": {
@@ -9571,9 +9605,9 @@
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.2",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
         },
         "is-valid-glob": {
@@ -9586,8 +9620,8 @@
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         }
       }
@@ -9597,8 +9631,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rethrow": {
@@ -9606,12 +9640,12 @@
       "resolved": "https://registry.npmjs.org/rethrow/-/rethrow-0.2.3.tgz",
       "integrity": "sha1-xVKPGQ6J7HU1iJRSob5omWtfZhY=",
       "requires": {
-        "ansi-bgred": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "extend-shallow": "1.1.4",
-        "lazy-cache": "0.2.7",
-        "right-align": "0.1.3"
+        "ansi-bgred": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "extend-shallow": "^1.1.4",
+        "lazy-cache": "^0.2.3",
+        "right-align": "^0.1.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9619,7 +9653,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -9639,7 +9673,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -9647,7 +9681,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -9655,12 +9689,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -9670,7 +9704,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -9704,7 +9738,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-value": {
@@ -9712,9 +9746,9 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
       "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "isobject": "2.1.0",
-        "to-object-path": "0.2.0"
+        "extend-shallow": "^2.0.1",
+        "isobject": "^2.0.0",
+        "to-object-path": "^0.2.0"
       },
       "dependencies": {
         "to-object-path": {
@@ -9722,8 +9756,8 @@
           "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
           "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "is-arguments": "1.0.2"
+            "arr-flatten": "^1.0.1",
+            "is-arguments": "^1.0.2"
           }
         }
       }
@@ -9733,10 +9767,10 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -9744,7 +9778,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -9774,9 +9808,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "sort-object-arrays": {
@@ -9784,7 +9818,7 @@
       "resolved": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
       "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9792,7 +9826,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -9803,8 +9837,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -9819,8 +9853,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -9834,7 +9868,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9842,8 +9876,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -9851,7 +9885,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -9866,9 +9900,9 @@
       "resolved": "https://registry.npmjs.org/src-stream/-/src-stream-0.1.1.tgz",
       "integrity": "sha1-2T9G0oGjcAKB7A8wszoDFDiUpoE=",
       "requires": {
-        "duplexify": "3.6.0",
-        "merge-stream": "0.1.8",
-        "through2": "2.0.3"
+        "duplexify": "^3.4.2",
+        "merge-stream": "^0.1.8",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -9881,7 +9915,7 @@
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
           "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
           "requires": {
-            "through2": "0.6.5"
+            "through2": "^0.6.1"
           },
           "dependencies": {
             "through2": {
@@ -9889,21 +9923,21 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               }
             }
           }
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9920,15 +9954,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-extend": {
@@ -9936,8 +9970,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       }
     },
     "stream-buffers": {
@@ -9948,11 +9982,11 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "requires": {
-        "duplexer": "0.1.1",
-        "through": "2.3.8"
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-exhaust": {
@@ -9971,9 +10005,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -9981,7 +10015,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-author": {
@@ -9994,7 +10028,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -10002,7 +10036,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-buffer": {
@@ -10010,8 +10044,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
       "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
       "requires": {
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1"
+        "is-buffer": "^1.1.0",
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-stream": {
@@ -10019,8 +10053,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "strip-bom-string": {
@@ -10039,7 +10073,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -10072,7 +10106,7 @@
       "resolved": "https://registry.npmjs.org/tableize-object/-/tableize-object-0.1.0.tgz",
       "integrity": "sha1-fCngEzsn1ItWuedtOijSQd8bOiQ=",
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.0.0"
       }
     },
     "tar": {
@@ -10082,9 +10116,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-fs": {
@@ -10094,10 +10128,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.1"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
@@ -10107,8 +10141,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -10119,13 +10153,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "template-error": {
@@ -10133,10 +10167,10 @@
       "resolved": "https://registry.npmjs.org/template-error/-/template-error-0.1.2.tgz",
       "integrity": "sha1-GMn2ANkPLz37oIM+N/fLb0E1QtQ=",
       "requires": {
-        "engine": "0.1.12",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "rethrow": "0.2.3"
+        "engine": "^0.1.5",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "rethrow": "^0.2.3"
       },
       "dependencies": {
         "kind-of": {
@@ -10144,7 +10178,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -10159,39 +10193,39 @@
       "resolved": "https://registry.npmjs.org/templates/-/templates-0.24.3.tgz",
       "integrity": "sha1-i6uicOGlcnR022hXX4Ic4bT+TQU=",
       "requires": {
-        "array-sort": "0.1.4",
-        "async-each": "1.0.1",
-        "base": "0.11.2",
-        "base-data": "0.6.2",
-        "base-engines": "0.2.1",
-        "base-helpers": "0.1.1",
-        "base-option": "0.8.4",
-        "base-plugins": "0.4.13",
-        "base-routes": "0.2.2",
-        "debug": "2.6.9",
-        "deep-bind": "0.3.0",
-        "define-property": "0.2.5",
-        "engine-base": "0.1.3",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "falsey": "0.3.2",
-        "get-value": "2.0.6",
-        "get-view": "0.1.3",
-        "group-array": "0.3.3",
-        "has-glob": "0.1.1",
-        "has-value": "0.3.1",
-        "inflection": "1.12.0",
-        "is-valid-app": "0.2.1",
-        "layouts": "0.11.0",
-        "lazy-cache": "2.0.2",
-        "match-file": "0.2.2",
-        "mixin-deep": "1.3.1",
-        "paginationator": "0.1.4",
-        "pascalcase": "0.1.1",
-        "set-value": "0.3.3",
-        "template-error": "0.1.2",
-        "vinyl-item": "0.1.0",
-        "vinyl-view": "0.1.2"
+        "array-sort": "^0.1.2",
+        "async-each": "^1.0.0",
+        "base": "^0.11.1",
+        "base-data": "^0.6.0",
+        "base-engines": "^0.2.0",
+        "base-helpers": "^0.1.1",
+        "base-option": "^0.8.3",
+        "base-plugins": "^0.4.13",
+        "base-routes": "^0.2.1",
+        "debug": "^2.2.0",
+        "deep-bind": "^0.3.0",
+        "define-property": "^0.2.5",
+        "engine-base": "^0.1.2",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "falsey": "^0.3.0",
+        "get-value": "^2.0.6",
+        "get-view": "^0.1.1",
+        "group-array": "^0.3.0",
+        "has-glob": "^0.1.1",
+        "has-value": "^0.3.1",
+        "inflection": "^1.10.0",
+        "is-valid-app": "^0.2.0",
+        "layouts": "^0.11.0",
+        "lazy-cache": "^2.0.1",
+        "match-file": "^0.2.0",
+        "mixin-deep": "^1.1.3",
+        "paginationator": "^0.1.3",
+        "pascalcase": "^0.1.1",
+        "set-value": "^0.3.3",
+        "template-error": "^0.1.2",
+        "vinyl-item": "^0.1.0",
+        "vinyl-view": "^0.1.2"
       }
     },
     "text-table": {
@@ -10201,7 +10235,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -10209,8 +10243,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "through2-filter": {
@@ -10218,8 +10252,8 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "time-diff": {
@@ -10227,10 +10261,10 @@
       "resolved": "https://registry.npmjs.org/time-diff/-/time-diff-0.3.1.tgz",
       "integrity": "sha1-Jej7c07qnmy15LA5TwWBC5yHwtg=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "2.1.0",
-        "log-utils": "0.1.5",
-        "pretty-time": "0.2.0"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "log-utils": "^0.1.0",
+        "pretty-time": "^0.2.0"
       },
       "dependencies": {
         "ansi-colors": {
@@ -10238,33 +10272,33 @@
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
           "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
           "requires": {
-            "ansi-bgblack": "0.1.1",
-            "ansi-bgblue": "0.1.1",
-            "ansi-bgcyan": "0.1.1",
-            "ansi-bggreen": "0.1.1",
-            "ansi-bgmagenta": "0.1.1",
-            "ansi-bgred": "0.1.1",
-            "ansi-bgwhite": "0.1.1",
-            "ansi-bgyellow": "0.1.1",
-            "ansi-black": "0.1.1",
-            "ansi-blue": "0.1.1",
-            "ansi-bold": "0.1.1",
-            "ansi-cyan": "0.1.1",
-            "ansi-dim": "0.1.1",
-            "ansi-gray": "0.1.1",
-            "ansi-green": "0.1.1",
-            "ansi-grey": "0.1.1",
-            "ansi-hidden": "0.1.1",
-            "ansi-inverse": "0.1.1",
-            "ansi-italic": "0.1.1",
-            "ansi-magenta": "0.1.1",
-            "ansi-red": "0.1.1",
-            "ansi-reset": "0.1.1",
-            "ansi-strikethrough": "0.1.1",
-            "ansi-underline": "0.1.1",
-            "ansi-white": "0.1.1",
-            "ansi-yellow": "0.1.1",
-            "lazy-cache": "0.2.7"
+            "ansi-bgblack": "^0.1.1",
+            "ansi-bgblue": "^0.1.1",
+            "ansi-bgcyan": "^0.1.1",
+            "ansi-bggreen": "^0.1.1",
+            "ansi-bgmagenta": "^0.1.1",
+            "ansi-bgred": "^0.1.1",
+            "ansi-bgwhite": "^0.1.1",
+            "ansi-bgyellow": "^0.1.1",
+            "ansi-black": "^0.1.1",
+            "ansi-blue": "^0.1.1",
+            "ansi-bold": "^0.1.1",
+            "ansi-cyan": "^0.1.1",
+            "ansi-dim": "^0.1.1",
+            "ansi-gray": "^0.1.1",
+            "ansi-green": "^0.1.1",
+            "ansi-grey": "^0.1.1",
+            "ansi-hidden": "^0.1.1",
+            "ansi-inverse": "^0.1.1",
+            "ansi-italic": "^0.1.1",
+            "ansi-magenta": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "ansi-reset": "^0.1.1",
+            "ansi-strikethrough": "^0.1.1",
+            "ansi-underline": "^0.1.1",
+            "ansi-white": "^0.1.1",
+            "ansi-yellow": "^0.1.1",
+            "lazy-cache": "^0.2.4"
           }
         },
         "lazy-cache": {
@@ -10277,13 +10311,13 @@
           "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
           "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
           "requires": {
-            "ansi-colors": "0.1.0",
-            "error-symbol": "0.1.0",
-            "info-symbol": "0.1.0",
-            "log-ok": "0.1.1",
-            "success-symbol": "0.1.0",
-            "time-stamp": "1.1.0",
-            "warning-symbol": "0.1.0"
+            "ansi-colors": "^0.1.0",
+            "error-symbol": "^0.1.0",
+            "info-symbol": "^0.1.0",
+            "log-ok": "^0.1.1",
+            "success-symbol": "^0.1.0",
+            "time-stamp": "^1.0.1",
+            "warning-symbol": "^0.1.0"
           }
         }
       }
@@ -10298,11 +10332,11 @@
       "resolved": "https://registry.npmjs.org/to/-/to-0.2.9.tgz",
       "integrity": "sha1-C6Wlb+U1ONuSBc621+0heq5GNcQ=",
       "requires": {
-        "handy": "0.0.13",
-        "htmlparser": "1.7.7",
-        "js-yaml": "3.12.0",
-        "optimist": "0.6.1",
-        "underscore": "1.9.1"
+        "handy": ">= 0.0.11",
+        "htmlparser": ">= 1.7.6",
+        "js-yaml": ">= 1.0.2",
+        "optimist": ">= 0.3.5",
+        "underscore": ">= 1.4.0"
       }
     },
     "to-absolute-glob": {
@@ -10310,7 +10344,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "to-buffer": {
@@ -10324,8 +10358,8 @@
       "resolved": "https://registry.npmjs.org/to-choices/-/to-choices-0.2.0.tgz",
       "integrity": "sha1-IufnWgfWl9fkzsvVaxvwPBVlTXM=",
       "requires": {
-        "ansi-gray": "0.1.1",
-        "mixin-deep": "1.3.1"
+        "ansi-gray": "^0.1.1",
+        "mixin-deep": "^1.1.3"
       }
     },
     "to-file": {
@@ -10333,14 +10367,14 @@
       "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
       "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.2.4",
-        "glob-parent": "2.0.0",
-        "is-valid-glob": "0.3.0",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "vinyl": "1.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.2.4",
+        "glob-parent": "^2.0.0",
+        "is-valid-glob": "^0.3.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "vinyl": "^1.1.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -10348,7 +10382,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -10361,7 +10395,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -10371,7 +10405,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -10379,7 +10413,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -10391,8 +10425,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "trim-leading-lines": {
@@ -10400,7 +10434,7 @@
       "resolved": "https://registry.npmjs.org/trim-leading-lines/-/trim-leading-lines-0.1.1.tgz",
       "integrity": "sha1-DnysPoMELc+Vp07TaWbxd0TVwWk=",
       "requires": {
-        "is-whitespace": "0.3.0"
+        "is-whitespace": "^0.3.0"
       }
     },
     "trim-newlines": {
@@ -10415,7 +10449,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -10441,8 +10475,8 @@
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "union-value": {
@@ -10450,10 +10484,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -10461,10 +10495,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -10474,8 +10508,8 @@
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "requires": {
-        "json-stable-stringify": "1.0.1",
-        "through2-filter": "2.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
       }
     },
     "unset-value": {
@@ -10483,8 +10517,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -10499,35 +10533,35 @@
       "resolved": "https://registry.npmjs.org/update/-/update-0.7.4.tgz",
       "integrity": "sha1-saCRwRo+KK4xui7vWLcRuCzpixQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "assemble-core": "0.25.0",
-        "assemble-loader": "0.6.1",
-        "base-cli-process": "0.1.19",
-        "base-config-process": "0.1.9",
-        "base-generators": "0.4.6",
-        "base-questions": "0.7.4",
-        "base-runtimes": "0.2.0",
-        "base-store": "0.4.4",
-        "common-config": "0.1.0",
-        "data-store": "0.16.1",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "find-pkg": "0.1.2",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "gulp-choose-files": "0.1.3",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "parser-front-matter": "1.6.4",
-        "resolve-dir": "0.1.1",
-        "resolve-file": "0.2.2",
-        "set-blocking": "2.0.0",
-        "strip-color": "0.1.0",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "yargs-parser": "2.4.1"
+        "arr-union": "^3.1.0",
+        "assemble-core": "^0.25.0",
+        "assemble-loader": "^0.6.1",
+        "base-cli-process": "^0.1.18",
+        "base-config-process": "^0.1.9",
+        "base-generators": "^0.4.5",
+        "base-questions": "^0.7.3",
+        "base-runtimes": "^0.2.0",
+        "base-store": "^0.4.4",
+        "common-config": "^0.1.0",
+        "data-store": "^0.16.1",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "find-pkg": "^0.1.2",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.2",
+        "gulp-choose-files": "^0.1.3",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.2.1",
+        "parser-front-matter": "^1.4.1",
+        "resolve-dir": "^0.1.0",
+        "resolve-file": "^0.2.0",
+        "set-blocking": "^2.0.0",
+        "strip-color": "^0.1.0",
+        "text-table": "^0.2.0",
+        "through2": "^2.0.1",
+        "yargs-parser": "^2.4.1"
       }
     },
     "upper-case": {
@@ -10540,8 +10574,8 @@
       "resolved": "https://registry.npmjs.org/use/-/use-1.1.2.tgz",
       "integrity": "sha1-bjgy/rholXNJSsanrLX++zd7LNE=",
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
       }
     },
     "util-deprecate": {
@@ -10567,8 +10601,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -10578,9 +10612,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -10588,8 +10622,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
-        "clone": "1.0.4",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -10598,23 +10632,23 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
-        "duplexify": "3.6.0",
-        "glob-stream": "5.3.5",
-        "graceful-fs": "4.1.11",
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "0.3.0",
-        "lazystream": "1.0.0",
-        "lodash.isequal": "4.5.0",
-        "merge-stream": "1.0.1",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.6",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "1.0.0",
-        "through2": "2.0.3",
-        "through2-filter": "2.0.0",
-        "vali-date": "1.0.0",
-        "vinyl": "1.2.0"
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
       }
     },
     "vinyl-item": {
@@ -10622,16 +10656,16 @@
       "resolved": "https://registry.npmjs.org/vinyl-item/-/vinyl-item-0.1.0.tgz",
       "integrity": "sha1-8ngTyBFC66ScpYSd5PQvb6Dl4Jg=",
       "requires": {
-        "base": "0.8.1",
-        "base-option": "0.8.4",
-        "base-plugins": "0.4.13",
-        "clone": "1.0.4",
-        "clone-stats": "1.0.0",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "vinyl": "1.2.0"
+        "base": "^0.8.1",
+        "base-option": "^0.8.2",
+        "base-plugins": "^0.4.12",
+        "clone": "^1.0.2",
+        "clone-stats": "^1.0.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "vinyl": "^1.1.1"
       },
       "dependencies": {
         "base": {
@@ -10639,14 +10673,14 @@
           "resolved": "https://registry.npmjs.org/base/-/base-0.8.1.tgz",
           "integrity": "sha1-aQC7MA8sdZbJnz2DurhyLYGLdI8=",
           "requires": {
-            "arr-union": "3.1.0",
-            "cache-base": "0.8.5",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "lazy-cache": "1.0.4",
-            "mixin-deep": "1.3.1"
+            "arr-union": "^3.1.0",
+            "cache-base": "^0.8.2",
+            "class-utils": "^0.3.2",
+            "component-emitter": "^1.2.0",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "lazy-cache": "^1.0.3",
+            "mixin-deep": "^1.1.3"
           },
           "dependencies": {
             "lazy-cache": {
@@ -10661,16 +10695,16 @@
           "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           },
           "dependencies": {
             "isobject": {
@@ -10690,9 +10724,9 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "map-visit": {
@@ -10700,8 +10734,8 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -10709,7 +10743,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -10717,10 +10751,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -10728,10 +10762,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -10739,8 +10773,8 @@
           "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -10757,13 +10791,13 @@
       "resolved": "https://registry.npmjs.org/vinyl-view/-/vinyl-view-0.1.2.tgz",
       "integrity": "sha1-CaxtfIASEr8JJr2dQQb0XmxPyXc=",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "engine-base": "0.1.3",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.1",
-        "vinyl-item": "0.1.0"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "engine-base": "^0.1.2",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "vinyl-item": "^0.1.0"
       }
     },
     "walkdir": {
@@ -10782,7 +10816,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-pm-runs": {
@@ -10798,7 +10832,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "wordwrap": {
@@ -10816,7 +10850,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-json": {
@@ -10824,7 +10858,7 @@
       "resolved": "https://registry.npmjs.org/write-json/-/write-json-0.2.2.tgz",
       "integrity": "sha1-+k4VKennY6T5LwfZhBMX49JI2vM=",
       "requires": {
-        "write": "0.2.1"
+        "write": "^0.2.1"
       }
     },
     "xtend": {
@@ -10837,8 +10871,8 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
       }
     },
     "zip-stream": {
@@ -10847,10 +10881,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.2",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "grunt": "^1.0.3",
+    "grunt-checktextdomain": "^1.0.1",
     "grunt-contrib-compress": "^1.4.3",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-phpcs": "^0.4.0",


### PR DESCRIPTION
Added task to verify textdomain strings are set correctly. https://github.com/studiopress/genesis-portfolio-pro/pull/34/commits/9ffa04556c7b777c91f17419b4558ce29dbb1ef2

@marksabbath Please could you review when you have time?

Usage is `grunt checktextdomain`. It's also run as the first step in `grunt build`.

It is the same task used in Genesis: https://github.com/studiopress/genesis/blob/develop/Gruntfile.js#L247-L275