### PR TITLE
Prepare Genesis Portfolio Pro 1.2.2 for release

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,3 +1,4 @@
+.circleci
 .git
 .gitignore
 .gitattributes

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "studiopress/genesis-portfolio-pro",
 	"type": "wordpress-plugin",
-	"description": "Plugin that add a new Portfolio post type where you can add portfolio entries with images and galleries to show of your visual content.",
+	"description": "Plugin that add a new Portfolio post type where you can add portfolio entries with images and galleries to show off your visual content.",
 	"homepage": "https://github.com/studiopress/genesis-portfolio-pro",
 	"license": "GPL-2.0-or-later",
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
 	},
 	"require-dev": {
 		"php": "^5.6 || ^7",
-		"dealerdirect/phpcodesniffer-composer-installer": "*",
-		"squizlabs/php_codesniffer": "^3.3.1",
-		"phpcompatibility/phpcompatibility-wp": "*",
-		"wp-coding-standards/wpcs": "^1",
-		"wp-cli/i18n-command": "^2.1"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+		"squizlabs/php_codesniffer": "^3.5",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"wp-coding-standards/wpcs": "^2.2",
+		"wp-cli/i18n-command": "^2.2"
 	},
 	"config": {
 		"sort-order": true
@@ -32,4 +32,3 @@
 		"source": "https://github.com/studiopress/genesis-portfolio-pro"
 	}
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e72718d5a133199b3fc4f50d9f2411c0",
+    "content-hash": "60fd357c0e8c2449f7d03aec42c7b079",
     "packages": [
         {
             "name": "composer/installers",
@@ -130,16 +130,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
                 "shasum": ""
             },
             "require": {
@@ -192,19 +192,19 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "time": "2020-01-29T20:22:20+00:00"
         },
         {
             "name": "gettext/gettext",
             "version": "v4.6.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/oscarotero/Gettext.git",
+                "url": "https://github.com/php-gettext/Gettext.git",
                 "reference": "70c6ff2fecd275e6ef9cdd542f55939a3d1904d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oscarotero/Gettext/zipball/70c6ff2fecd275e6ef9cdd542f55939a3d1904d6",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/70c6ff2fecd275e6ef9cdd542f55939a3d1904d6",
                 "reference": "70c6ff2fecd275e6ef9cdd542f55939a3d1904d6",
                 "shasum": ""
             },
@@ -261,12 +261,12 @@
             "version": "2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mlocati/cldr-to-gettext-plural-rules.git",
+                "url": "https://github.com/php-gettext/Languages.git",
                 "reference": "78db2d17933f0765a102f368a6663f057162ddbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/cldr-to-gettext-plural-rules/zipball/78db2d17933f0765a102f368a6663f057162ddbd",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/78db2d17933f0765a102f368a6663f057162ddbd",
                 "reference": "78db2d17933f0765a102f368a6663f057162ddbd",
                 "shasum": ""
             },
@@ -518,16 +518,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
                 "shasum": ""
             },
             "require": {
@@ -535,10 +535,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -564,7 +564,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-10-07T18:31:37+00:00"
+            "time": "2019-08-28T14:22:28+00:00"
         },
         {
             "name": "rmccue/requests",
@@ -617,16 +617,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
                 "shasum": ""
             },
             "require": {
@@ -664,7 +664,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2020-01-30T22:20:29+00:00"
         },
         {
             "name": "symfony/finder",
@@ -717,26 +717,26 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.1.2",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "e52a9a602772339a0f844bd5e9a9ac8cc8b490ea"
+                "reference": "379d2b07e8555efb2a6ccd94ef3d75414aa03a88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/e52a9a602772339a0f844bd5e9a9ac8cc8b490ea",
-                "reference": "e52a9a602772339a0f844bd5e9a9ac8cc8b490ea",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/379d2b07e8555efb2a6ccd94ef3d75414aa03a88",
+                "reference": "379d2b07e8555efb2a6ccd94ef3d75414aa03a88",
                 "shasum": ""
             },
             "require": {
-                "gettext/gettext": "^4.6",
+                "gettext/gettext": "^4.6.3",
                 "mck89/peast": "^1.8",
                 "wp-cli/wp-cli": "^2"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^2.1"
+                "wp-cli/wp-cli-tests": "^2.1.3"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -770,7 +770,7 @@
             ],
             "description": "Provides internationalization tools for WordPress projects.",
             "homepage": "https://github.com/wp-cli/i18n-command",
-            "time": "2019-04-25T00:31:04+00:00"
+            "time": "2019-08-13T16:32:54+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -934,27 +934,29 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.2.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "^9.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -964,7 +966,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -973,7 +975,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-12-18T09:43:51+00:00"
+            "time": "2020-02-04T02:52:06+00:00"
         }
     ],
     "aliases": [],
@@ -986,5 +988,6 @@
     },
     "platform-dev": {
         "php": "^5.6 || ^7"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/languages/genesis-portfolio-pro.pot
+++ b/languages/genesis-portfolio-pro.pot
@@ -1,18 +1,38 @@
-# Copyright (C) 2019 StudioPress
-# This file is distributed under the same license as the Genesis Portfolio Pro package.
+# Copyright (C) 2020 StudioPress
+# This file is distributed under the same license as the Genesis Portfolio Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Portfolio Pro 1.2.1\n"
-"Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/genesis-portfolio-pro\n"
-"POT-Creation-Date: 2019-07-11 14:42:10+00:00\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"Project-Id-Version: Genesis Portfolio Pro 1.2.2\n"
+"Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"X-Generator: node-wp-i18n 1.2.3\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2020-04-15T16:59:10+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.2.0\n"
+"X-Domain: genesis-portfolio-pro\n"
+
+#. Plugin Name of the plugin
+msgid "Genesis Portfolio Pro"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://wordpress.org/plugins/genesis-portfolio-pro/"
+msgstr ""
+
+#. Description of the plugin
+msgid "Adds default portfolio to any Genesis HTML5 theme."
+msgstr ""
+
+#. Author of the plugin
+msgid "StudioPress"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://www.studiopress.com"
+msgstr ""
 
 #: lib/classes/class-genesis-portfolio-archive-settings.php:36
 msgid "Items Per Page"
@@ -32,6 +52,16 @@ msgstr ""
 
 #: lib/classes/class-genesis-portfolio-widget.php:65
 msgid "Genesis - Portfolio"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:18
+msgctxt "taxonomy general name"
+msgid "Portfolio Types"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:19
+msgctxt "taxonomy singular name"
+msgid "Portfolio Type"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:20
@@ -83,40 +113,75 @@ msgstr ""
 msgid "Portfolio Types"
 msgstr ""
 
+#: lib/post-types-and-taxonomies.php:39
+msgctxt "portfolio-type slug"
+msgid "portfolio-type"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:55
+msgctxt "post type general name"
+msgid "Portfolio Items"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:56
+msgctxt "post type singular name"
+msgid "Portfolio Item"
+msgstr ""
+
 #: lib/post-types-and-taxonomies.php:57
-msgid "Add New Portfolio Item"
+msgctxt "admin menu"
+msgid "Portfolio Items"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:58
-msgid "New Portfolio Item"
+msgctxt "add new on admin bar"
+msgid "Portfolio Item"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:59
-msgid "Edit Portfolio Item"
+msgctxt "Portfolio Item"
+msgid "Add New"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:60
-msgid "View Portfolio Item"
+msgid "Add New Portfolio Item"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:61
-msgid "All Portfolio Items"
+msgid "New Portfolio Item"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:62
-msgid "Search Portfolio Items"
+msgid "Edit Portfolio Item"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:63
-msgid "Parent Portfolio Items:"
+msgid "View Portfolio Item"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:64
-msgid "No Portfolio Items found."
+msgid "All Portfolio Items"
 msgstr ""
 
 #: lib/post-types-and-taxonomies.php:65
+msgid "Search Portfolio Items"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:66
+msgid "Parent Portfolio Items:"
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:67
+msgid "No Portfolio Items found."
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:68
 msgid "No Portfolio Items found in Trash."
+msgstr ""
+
+#: lib/post-types-and-taxonomies.php:76
+msgctxt "portfolio slug"
+msgid "portfolio"
 msgstr ""
 
 #: lib/views/admin/archive-settings/posts-per-page-meta.php:14
@@ -262,69 +327,4 @@ msgstr ""
 
 #: lib/views/widget/portfolio.php:108
 msgid "(no title)"
-msgstr ""
-
-#. Plugin Name of the plugin/theme
-msgid "Genesis Portfolio Pro"
-msgstr ""
-
-#. Plugin URI of the plugin/theme
-msgid "https://wordpress.org/plugins/genesis-portfolio-pro/"
-msgstr ""
-
-#. Description of the plugin/theme
-msgid "Adds default portfolio to any Genesis HTML5 theme."
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "StudioPress"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "https://www.studiopress.com"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:18
-msgctxt "taxonomy general name"
-msgid "Portfolio Types"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:19
-msgctxt "taxonomy singular name"
-msgid "Portfolio Type"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:39
-msgctxt "portfolio-type slug"
-msgid "portfolio-type"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:52
-msgctxt "post type general name"
-msgid "Portfolio Items"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:53
-msgctxt "post type singular name"
-msgid "Portfolio Item"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:54
-msgctxt "admin menu"
-msgid "Portfolio Items"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:55
-msgctxt "add new on admin bar"
-msgid "Portfolio Item"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:56
-msgctxt "Portfolio Item"
-msgid "Add New"
-msgstr ""
-
-#: lib/post-types-and-taxonomies.php:72
-msgctxt "portfolio slug"
-msgid "portfolio"
 msgstr ""

--- a/lib/classes/class-genesis-portfolio-archive-settings.php
+++ b/lib/classes/class-genesis-portfolio-archive-settings.php
@@ -68,7 +68,7 @@ class Genesis_Portfolio_Archive_Settings {
 
 		$label_attr = $this->settings_field . '-posts_per_page';
 		$name_attr  = $this->settings_field . '[posts_per_page]';
-		$value      = $opts['posts_per_page'] ?: get_option( 'posts_per_page' );
+		$value      = $opts['posts_per_page'] ?: get_option( 'posts_per_page' ); // phpcs:ignore WordPress.PHP.DisallowShortTernary
 
 		include GENESIS_PORTFOLIO_VIEWS . '/admin/archive-settings/posts-per-page-meta.php';
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "genesis-portfolio-pro",
   "main_plugin_file": "plugin",
   "title": "Genesis Portfolio Pro",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "GPL-2.0-or-later",
   "licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",
   "description": "Plugin that add a new Portfolio post type where you can add portfolio entries with images and galleries to show off your visual content.",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.1",
   "license": "GPL-2.0-or-later",
   "licenseuri": "https://www.gnu.org/licenses/gpl-2.0.html",
-  "description": "Plugin that add a new Portfolio post type where you can add portfolio entries with images and galleries to show of your visual content.",
+  "description": "Plugin that add a new Portfolio post type where you can add portfolio entries with images and galleries to show off your visual content.",
   "main": "Gruntfile.js",
   "repository": {
     "type": "git",

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
  * Plugin Name: Genesis Portfolio Pro
  * Plugin URI: https://wordpress.org/plugins/genesis-portfolio-pro/
  * Description: Adds default portfolio to any Genesis HTML5 theme.
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: StudioPress
  * Author URI: https://www.studiopress.com
  * Text Domain: genesis-portfolio-pro

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru, nick_thegeek, bgardner, marksab
 Tags: genesis, portfolio, templates
 Requires at least: 4.4
 Tested up to: 5.4
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,10 @@ Custom templates are supported using the WordPress template hierarchy and the po
 
 
 == Changelog ==
+
+= 1.2.2 =
+* REST: Expose the Portfolio post type and Portfolio Type taxonomy to the REST API.
+* Tooling: Generate language file with WP-CLI instead of Node.js.
 
 = 1.2.1 =
 * Conform to WordPress Development Standards for PHP


### PR DESCRIPTION
Addresses #48 by completing release tasks for 1.2.2. (We bumped tested up to to 5.4 but also had some unreleased changes in develop that I tracked down here for the changelog.)

Also:
- Updates composer dev dependencies (phpcs was failing to run locally before I did this).
- “Fixes“ (ignores) a phpcs warning about a short ternary. I think phpcs is just heightist.

### How to test
Code review. 

### Documentation
No documentation required.

### Notes
Once this is reviewed, I can merge to master manually and test @BMO-tech's and @nathanrice's CI work by tagging for release. 🙌 for the automation work!
