### PR TITLE
ci: minor updates to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
+            echo "export VERSION=$(git -C /tmp/src describe --tags --abbrev=0)" >> ${BASH_ENV}
 
   show_pwd_info:
     description: "Show information about the current directory"


### PR DESCRIPTION
This is a simple change in the way the the latest version is extracted. It uses `git describe` to fetch the latest tag.