### PR TITLE
Remove `wp_make_content_images_responsive`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -617,16 +617,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -664,7 +664,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/finder",
@@ -988,6 +988,5 @@
     },
     "platform-dev": {
         "php": "^5.6 || ^7"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/genesis-portfolio-pro.php
+++ b/genesis-portfolio-pro.php
@@ -138,7 +138,7 @@ function genesis_portfolio_archive_setting_defaults( $defaults = array(), $post_
 
 register_activation_hook( __FILE__, 'genesis_portfolio_rewrite_flush' );
 /**
- * Activation hook action to flush the rewrit rules for the custom post type and taxonomy
+ * Activation hook action to flush the rewrite rules for the custom post type and taxonomy
  *
  * @since 0.1.0
  */

--- a/lib/views/widget/portfolio.php
+++ b/lib/views/widget/portfolio.php
@@ -77,7 +77,7 @@ if ( $portfolio_query->have_posts() ) {
 		if ( $image && $instance['show_image'] ) {
 			$state = empty( $instance['show_title'] ) ? '' : 'aria-hidden="true"';
 			// phpcs:ignore
-			printf( '<a href="%s" class="%s" %s>%s</a>', esc_url( get_permalink() ), esc_attr( $instance['image_alignment'] ), $state, wp_make_content_images_responsive( $image ) );
+			printf( '<a href="%s" class="%s" %s>%s</a>', esc_url( get_permalink() ), esc_attr( $instance['image_alignment'] ), $state, $image );
 		}
 
 		if ( $instance['show_title'] ) {


### PR DESCRIPTION
Images already get `srcset` via `wp_calculate_image_srcset` in `wp_get_attachment_image`. 

`wp_make_content_images_responsive` is deprecated in WordPress 5.5.

Fixes #52

### How to test
<!-- Detailed steps to test this PR. -->
1. Install WP 5.5 and a Genesis child theme along with this plugin branch.
2. Create a portfolio item (Portfolio Items > Add new) and set a featured image.
3. Add a Genesis - Portfolio widget to a widget area.
4. Make sure the image includes `srcset` and `sizes`.

Note: images will only include `srcset` and `sizes` if the image has a similar aspect ratio to 300x200. Upload an image that is much larger to test. 

### Documentation
No documentation required. 
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
Removed use of `wp_make_content_images_responsive` portfolio widget images; `srcset` is applied via `wp_calculate_image_srcset` in `wp_get_attachment_image` used by `genesis_get_image`.

### Notes
<!-- Additional information for reviewers. -->